### PR TITLE
10 implement contraction expansion for pos tagger

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 itertools = "*"
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,5 @@ edition = "2021"
 
 [dependencies]
 itertools = "*"
+serde = "1.0"
+serde_json = "1.0"

--- a/data/contractions.json
+++ b/data/contractions.json
@@ -1,0 +1,499 @@
+{
+  "ain't":[
+    "am not",
+    "is not",
+    "are not",
+    "has not",
+    "have not",
+    "did not"
+  ],
+  "amn't":[
+    "am not"
+  ],
+  "aren't":[
+    "are not",
+    "am not"
+  ],
+  "can't":[
+    "cannot"
+  ],
+  "cain't":[
+    "cannot"
+  ],
+  "'cause":[
+    "because"
+  ],
+  "cause":[
+    "because"
+  ],
+  "could've":[
+    "could have"
+  ],
+  "couldn't":[
+    "could not"
+  ],
+  "couldn't've":[
+    "could not have"
+  ],
+  "daren't":[
+    "dare not",
+    "dared not"
+  ],
+  "dasn't":[
+    "dare not"
+  ],
+  "didn't":[
+    "did not"
+  ],
+  "doesn't":[
+    "does not"
+  ],
+  "don't":[
+    "do not",
+    "does not"
+  ],
+  "d'ye":[
+    "do you",
+    "did you"
+  ],
+  "e'er":[
+    "ever"
+  ],
+  "everybody's":[
+    "everybody is"
+  ],
+  "everyone's":[
+    "everyone is"
+  ],
+  "finna":[
+    "fixing to",
+    "going to"
+  ],
+  "g'day":[
+    "good day"
+  ],
+  "gimme":[
+    "give me"
+  ],
+  "giv'n":[
+    "given"
+  ],
+  "gonna":[
+    "going to"
+  ],
+  "gon't":[
+    "go not"
+  ],
+  "gotta":[
+    "got to"
+  ],
+  "hadn't":[
+    "had not"
+  ],
+  "had've":[
+    "had have"
+  ],
+  "hasn't":[
+    "has not"
+  ],
+  "haven't":[
+    "have not"
+  ],
+  "he'd":[
+    "he had",
+    "he would"
+  ],
+  "he'll":[
+    "he will",
+    "he shall"
+  ],
+  "he's":[
+    "he has",
+    "he is"
+  ],
+  "he've":[
+    "he have"
+  ],
+  "how'd":[
+    "how did",
+    "how would"
+  ],
+  "howdy":[
+    "how do you do",
+    "how do you fare"
+  ],
+  "how'll":[
+    "how will"
+  ],
+  "how're":[
+    "how are"
+  ],
+  "how's":[
+    "how is",
+    "how has",
+    "how does"
+  ],
+  "I'd":[
+    "I had",
+    "I would"
+  ],
+  "I'd've":[
+    "I would have"
+  ],
+  "I'll":[
+    "I will",
+    "I shall"
+  ],
+  "I'm":[
+    "I am"
+  ],
+  "I'm'a":[
+    "I am about to"
+  ],
+  "Imma":[
+    "I am about to"
+  ],
+  "I'm'o":[
+    "I am going to"
+  ],
+  "innit":[
+    "is it not"
+  ],
+  "I've":[
+    "I have"
+  ],
+  "isn't":[
+    "is not"
+  ],
+  "it'd":[
+    "it would"
+  ],
+  "it'll":[
+    "it will",
+    "it shall"
+  ],
+  "it's":[
+    "it is",
+    "it has"
+  ],
+  "let's":[
+    "let us"
+  ],
+  "ma'am":[
+    "madam"
+  ],
+  "mayn't":[
+    "may not"
+  ],
+  "may've":[
+    "may have"
+  ],
+  "methinks":[
+    "me thinks"
+  ],
+  "mightn't":[
+    "might not"
+  ],
+  "might've":[
+    "might have"
+  ],
+  "mustn't":[
+    "must not"
+  ],
+  "mustn't've":[
+    "must not have"
+  ],
+  "must've":[
+    "must have"
+  ],
+  "needn't":[
+    "need not"
+  ],
+  "ne'er":[
+    "never"
+  ],
+  "o'clock":[
+    "of the clock"
+  ],
+  "o'er":[
+    "over"
+  ],
+  "ol'":[
+    "old"
+  ],
+  "oughtn't":[
+    "ought not"
+  ],
+  "'s":[
+    "is",
+    "has",
+    "does",
+    "or us"
+  ],
+  "shalln't":[
+    "shall not"
+  ],
+  "shan't":[
+    "shall not"
+  ],
+  "she'd":[
+    "she had",
+    "she would"
+  ],
+  "she'll":[
+    "she will",
+    "she shall"
+  ],
+  "she's":[
+    "she is",
+    "she has"
+  ],
+  "should've":[
+    "should have"
+  ],
+  "shouldn't":[
+    "should not"
+  ],
+  "shouldn't've":[
+    "should not have"
+  ],
+  "somebody's":[
+    "somebody is",
+    "somebody has"
+  ],
+  "someone's":[
+    "someone is",
+    "someone has"
+  ],
+  "something's":[
+    "something is",
+    "something has"
+  ],
+  "so're":[
+    "so are"
+  ],
+  "that'll":[
+    "that will",
+    "that shall"
+  ],
+  "that're":[
+    "that are"
+  ],
+  "that's":[
+    "that is",
+    "that has"
+  ],
+  "that'd":[
+    "that would",
+    "that had"
+  ],
+  "there'd":[
+    "there had",
+    "there would"
+  ],
+  "there'll":[
+    "there will",
+    "there shall"
+  ],
+  "there're":[
+    "there are"
+  ],
+  "there's":[
+    "there is",
+    "there has"
+  ],
+  "these're":[
+    "these are"
+  ],
+  "these've":[
+    "these have"
+  ],
+  "they'd":[
+    "they had",
+    "they would"
+  ],
+  "they'll":[
+    "they will",
+    "they shall"
+  ],
+  "they're":[
+    "they are",
+    "they were"
+  ],
+  "they've":[
+    "they have"
+  ],
+  "this's":[
+    "this is",
+    "this has"
+  ],
+  "those're":[
+    "those are"
+  ],
+  "those've":[
+    "those have"
+  ],
+  "'tis":[
+    "it is"
+  ],
+  "to've":[
+    "to have"
+  ],
+  "'twas":[
+    "it was"
+  ],
+  "twas":[
+    "it was"
+  ],
+  "wanna":[
+    "want to"
+  ],
+  "wasn't":[
+    "was not"
+  ],
+  "we'd":[
+    "we had",
+    "we would",
+    "we did"
+  ],
+  "we'd've":[
+    "we would have"
+  ],
+  "we'll":[
+    "we will",
+    "we shall"
+  ],
+  "we're":[
+    "we are"
+  ],
+  "we've":[
+    "we have"
+  ],
+  "weren't":[
+    "were not"
+  ],
+  "what'd":[
+    "what did"
+  ],
+  "what'll":[
+    "what will",
+    "what shall"
+  ],
+  "what're":[
+    "what are",
+    "what were"
+  ],
+  "what's":[
+    "what is",
+    "what has",
+    "what does"
+  ],
+  "what've":[
+    "what have"
+  ],
+  "when's":[
+    "when is"
+  ],
+  "where'd":[
+    "where did"
+  ],
+  "where'll":[
+    "where will",
+    "where shall"
+  ],
+  "where're":[
+    "where are"
+  ],
+  "where's":[
+    "where is",
+    "where has",
+    "where does"
+  ],
+  "where've":[
+    "where have"
+  ],
+  "which'd":[
+    "which had",
+    "which would"
+  ],
+  "which'll":[
+    "which will",
+    "which shall"
+  ],
+  "which're":[
+    "which are"
+  ],
+  "which's":[
+    "which is",
+    "which has"
+  ],
+  "which've":[
+    "which have"
+  ],
+  "who'd":[
+    "who did",
+    "who had",
+    "who would"
+  ],
+  "who'd've":[
+    "who would have"
+  ],
+  "who'll":[
+    "who will",
+    "who shall"
+  ],
+  "who's":[
+    "who is",
+    "who does",
+    "who has"
+  ],
+  "who've":[
+    "who have"
+  ],
+  "why'd":[
+    "why did"
+  ],
+  "why're":[
+    "why are"
+  ],
+  "why's":[
+    "why is",
+    "why does",
+    "why has"
+  ],
+  "won't":[
+    "will not"
+  ],
+  "would've":[
+    "would have"
+  ],
+  "wouldn't":[
+    "would not"
+  ],
+  "y'all":[
+    "you all"
+  ],
+  "y'all'd've":[
+    "you all would have"
+  ],
+  "y'all're":[
+    "you all are"
+  ],
+  "you'd":[
+    "you would",
+    "you had"
+  ],
+  "you'll":[
+    "you will",
+    "you shall"
+  ],
+  "you're":[
+    "you are"
+  ],
+  "you've":[
+    "you have"
+  ],
+  "<noun>'s":[
+    "<noun> is"
+  ]
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,8 +6,6 @@ mod rs_lex_rulespec_id;
 mod rs_lexical_ruleset;
 mod rs_lexical_rulespec;
 
-
-
 use std::collections::HashMap;
 use std::fs;
 use std::io::{self, Error, Write};

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod rs_contextual_rulespec;
 mod rs_lex_rulespec_id;
 mod rs_lexical_ruleset;
 mod rs_lexical_rulespec;
+mod rs_contractions;
 
 use std::collections::HashMap;
 use std::fs;
@@ -12,6 +13,7 @@ use std::io::{self, Error, Write};
 use rs_wordclass::*;
 use rs_contextual_rulespec::*;
 use rs_contextual_ruleset::*;
+use rs_contractions::*;
 
 type WordclassMap = HashMap<String, Vec<Wordclass>>;
 
@@ -58,10 +60,9 @@ fn format_vec(wordclasses: &Vec<Wordclass>) -> String {
 
 
 fn main() -> io::Result<()> {
+    test_contractions();
 
     let contextual_ruleset: HashMap<Wordclass, Vec<ContextualRulespec>> = parse_contextual_ruleset("data/rulefile_contextual.txt")?;
-    //let lexical_ruleset: Vec<LexicalRulespec> = parse_lexical_ruleset("data/rulefile_lexical.txt")?;
-
     let tagger: WordclassMap = initialize_tagger("data/lexicon.txt")?;
 
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use std::io::{self, Error, Write};
 use rs_wordclass::*;
 use rs_contextual_rulespec::*;
 use rs_contextual_ruleset::*;
-use rs_contractions::*;
 
 type WordclassMap = HashMap<String, Vec<Wordclass>>;
 
@@ -60,7 +59,6 @@ fn format_vec(wordclasses: &Vec<Wordclass>) -> String {
 
 
 fn main() -> io::Result<()> {
-    test_contractions();
 
     let contextual_ruleset: HashMap<Wordclass, Vec<ContextualRulespec>> = parse_contextual_ruleset("data/rulefile_contextual.txt")?;
     let tagger: WordclassMap = initialize_tagger("data/lexicon.txt")?;

--- a/src/rs_contractions.rs
+++ b/src/rs_contractions.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+use std::fs;
+use serde::{Deserialize};
+use serde_json;
+use std::io;
+
+#[derive(Deserialize, Debug)]
+struct Contractions {
+    #[serde(flatten)]
+    contractions: HashMap<String, Vec<String>>,
+}
+
+/// Function to load `data/contractions.json` as a hashmap of contractions to their expansions.
+fn load_contractions() -> Result<HashMap<String, Vec<String>>, io::Error> {
+    let data = fs::read_to_string("data/contractions.json")?;
+    let contractions: Contractions = serde_json::from_str(&data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    Ok(contractions.contractions)
+}
+
+/// Function to expand a contraction `input` according to the `contractions_map`.
+fn expand_contraction(input: String, contractions_map: &HashMap<String, Vec<String>>) -> Option<Vec<String>> {
+    contractions_map.get(&input).map(|expansion| expansion.clone())
+}
+
+/// Function to find contractions for a given `input`
+fn find_contractions(input: String) -> Result<Vec<String>, String> {
+    let contractions_map = load_contractions().map_err(|e| format!("Error loading contractions: {}", e))?;
+
+    // Map the `input` to its corresponding contraction
+    let mut result: Vec<String> = Vec::new();
+    if let Some(expansion) = expand_contraction(input.clone(), &contractions_map) {
+        match expansion.get(0) {
+            Some(first_expansion) => result.push(first_expansion.to_string()),  // Convert &str to String
+            None => return Err("Empty contraction vector.".to_string()),  // Error if empty
+        }
+    }
+
+    // If no contractions are found, return the original input as a single-element vector
+    if result.is_empty() { Ok(vec![input]) } else { Ok(result) }
+}
+
+
+pub fn test_contractions() {
+    let input = "you're";
+    match find_contractions(input.to_string()) {
+        Ok(expansions) => {
+            for contraction in expansions {
+                println!("{}", contraction); // Print each contraction
+            }
+        }
+        Err(e) => println!("Error: {}", e), // Print the error if any
+    }
+}

--- a/src/rs_contractions.rs
+++ b/src/rs_contractions.rs
@@ -4,11 +4,13 @@ use serde::{Deserialize};
 use serde_json;
 use std::io;
 
+/// Struct used to help parse contractions in `load_contractions`.
 #[derive(Deserialize, Debug)]
 struct Contractions {
     #[serde(flatten)]
     contractions: HashMap<String, Vec<String>>,
 }
+
 
 /// Function to load `data/contractions.json` as a hashmap of contractions to their expansions.
 fn load_contractions() -> Result<HashMap<String, Vec<String>>, io::Error> {
@@ -17,10 +19,12 @@ fn load_contractions() -> Result<HashMap<String, Vec<String>>, io::Error> {
     Ok(contractions.contractions)
 }
 
+
 /// Function to expand a contraction `input` according to the `contractions_map`.
 fn expand_contraction(input: String, contractions_map: &HashMap<String, Vec<String>>) -> Option<Vec<String>> {
     contractions_map.get(&input).map(|expansion| expansion.clone())
 }
+
 
 /// Function to find contractions for a given `input`
 fn find_contractions(input: String) -> Result<Vec<String>, String> {
@@ -30,7 +34,13 @@ fn find_contractions(input: String) -> Result<Vec<String>, String> {
     let mut result: Vec<String> = Vec::new();
     if let Some(expansion) = expand_contraction(input.clone(), &contractions_map) {
         match expansion.get(0) {
-            Some(first_expansion) => result.push(first_expansion.to_string()),  // Convert &str to String
+            Some(first_expansion) => {
+                result = first_expansion
+                    .to_string()
+                    .split_whitespace()
+                    .map(|s| s.to_string())  // Convert each &str to String
+                    .collect();                                          // Collect the results into a Vec<String>
+            }
             None => return Err("Empty contraction vector.".to_string()),  // Error if empty
         }
     }
@@ -40,14 +50,18 @@ fn find_contractions(input: String) -> Result<Vec<String>, String> {
 }
 
 
-pub fn test_contractions() {
-    let input = "you're";
-    match find_contractions(input.to_string()) {
-        Ok(expansions) => {
-            for contraction in expansions {
-                println!("{}", contraction); // Print each contraction
-            }
-        }
-        Err(e) => println!("Error: {}", e), // Print the error if any
-    }
+/// Test that the `expand_contraction` function correct expands out contractions.
+#[test]
+fn test_expand_contraction() {
+    // Test expansion of "you're" to "you" and "are".
+    let result = find_contractions("you're".to_string());
+    assert_eq!(result, Ok(vec!["you".to_string(), "are".to_string()]));
+
+    // Test expansion of "it's" to "it" and "is".
+    let result = find_contractions("it's".to_string());
+    assert_eq!(result, Ok(vec!["it".to_string(), "is".to_string()]));
+
+    // Test expansion of "chocolate" (it shouldn't expand so should just return ['chocolate'].
+    let result = find_contractions("chocolate".to_string());
+    assert_eq!(result, Ok(vec!["chocolate".to_string()]));
 }


### PR DESCRIPTION
## Pull Request Description
<!-- Please provide a concise summary of the changes introduced in this pull request, along with references to any related issues. Also, list any dependencies that are necessary for these changes. -->
This adds a module for contraction expansion, this means expanding out words such as `you're` to `you are` and `it's` to `it is`. It's not yet integrated as part of the main tagger, but this will come in a later issue.

### This pull request introduces the following updates:
- [ ] Resolves one or more bugs (non-breaking modification that addresses an issue).
- [X] Introduces one or more new features (non-breaking addition of new functionality).
- [ ] Adds documentation (such as Doxygen or other relevant documentation formats).
- [ ] Refactors code (non-breaking change aimed at improving code structure or readability).
- [ ] Adds one or more tests to the repository.
- [ ] Includes additional modifications (please specify).

### Commitments to the repository:
- [X] I have conducted a thorough self-review of the code.
- [X] I have implemented tests that validate the functionality of the fix or feature.
- [X] I have updated relevant documentation to reflect the changes made.
- [X] My changes do not introduce any new warnings or errors.
