### PR TITLE
Implement FCFS heuristic to apply brill rules

### DIFF
--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -14,7 +14,12 @@ fn tag_sentence(sentence: &str) {
 
     println!("sentence: {}\n", sentence);
 
-    let tokenised_sentence: Vec<String> = sentence.split_whitespace().map(|word|find_contractions(String::from(word)).unwrap()).flatten().collect();
+    let tokenised_sentence: Vec<String> = sentence.split_whitespace().
+        map(|word|find_contractions(String::from(word))
+            .unwrap())
+        .flatten()
+        .collect();
+
     println!("tokenised sentence: {:?}", tokenised_sentence);
 
     // Match each word with its list of possible tags

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -49,6 +49,7 @@ fn tag_sentence(sentence: &str) -> bool {
 
 }
 
+
 /// Apply lexical rules to a sentence `sentence_to_tag`
 fn apply_lexical_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, lexical_ruleset: &Vec<LexicalRulespec>) {
     for (index, (_, _)) in enumerate(sentence_to_tag.clone()) {
@@ -74,11 +75,8 @@ fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possib
             match valid_rules {
                 Some(_valid_rules) => {
                     for rule in _valid_rules {
-                        let possible_tags_for_word =     possible_tags.iter()
-                            .find(|(first, _)| *first == word) // Find the tuple where the first element matches `key`
-                            .map(|(_, second)| second).unwrap(); // Map to the second element
 
-                        if(!possible_tags_for_word.contains(&rule.target_tag)){continue;}
+                        if !is_tag_contained_in_word_possible_tags(possible_tags, &word, &rule.target_tag) {continue;}
 
                         match contextual_rule_apply(sentence_to_tag, index as i32, rule.clone()) {
                             Some(true) => {
@@ -137,6 +135,14 @@ fn retrieve_sentence_to_tag(sentence: Vec<(String, Vec<Wordclass>)>) -> Vec<(Str
         .filter_map(|(word, tags)| tags.first().map(|first_tag| (word.to_owned(), first_tag.clone()))).collect()
 }
 
+/// Function to check if `possible_tag`s of a given `word` contain `target_tag`.
+fn is_tag_contained_in_word_possible_tags(possible_tags: &Vec<(String, Vec<Wordclass>)>, word: &String, target_tag: &Wordclass) -> bool {
+    let possible_tags_for_word =     possible_tags.iter()
+        .find(|(first, _)| first == word) // Find the tuple where the first element matches `key`
+        .map(|(_, second)| second).unwrap(); // Map to the second element
+
+    possible_tags_for_word.contains(target_tag)
+}
 #[test]
 fn test_tag_sentence() {
     assert!(tag_sentence("i want to rock and roll every night"));

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -29,8 +29,8 @@ fn tag_sentence(sentence: &str) -> bool {
     println!("sentence to tag: {:?}", sentence_to_tag);
 
     // Apply lexical rules.
-    //println!("applying lexical rules\n");
-    //apply_lexical_rules(&mut sentence_to_tag, &lexical_ruleset);
+    println!("applying lexical rules\n");
+    apply_lexical_rules(&mut sentence_to_tag, &lexical_ruleset, &words_to_tags, &wc_mapping);
 
     // Apply contextual rules.
     println!("applying contextual rules:\n");
@@ -51,10 +51,13 @@ fn tag_sentence(sentence: &str) -> bool {
 
 
 /// Apply lexical rules to a sentence `sentence_to_tag`
-fn apply_lexical_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, lexical_ruleset: &Vec<LexicalRulespec>) {
-    for (index, (_, _)) in enumerate(sentence_to_tag.clone()) {
+fn apply_lexical_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, lexical_ruleset: &Vec<LexicalRulespec>, possible_tags: &Vec<(String, Vec<Wordclass>)>, wc_mapping: &WordclassMap) {
+    for (index, (word, _)) in enumerate(sentence_to_tag.clone()) {
         for rule in lexical_ruleset {
-            match lexical_rule_apply(sentence_to_tag, index as i32, rule) {
+
+            if !is_tag_contained_in_word_possible_tags(&possible_tags, &word, &rule.target_tag) {continue;}
+
+            match lexical_rule_apply(sentence_to_tag, index as i32, rule, wc_mapping) {
                 Some(true) => {
                     println!("RuleLexical (word {:?} -> {} if {} passes with parameters {:?})", &sentence_to_tag.get(index), rule.target_tag, rule.ruleset_id, rule.parameters);
                 }

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -82,8 +82,11 @@ fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possib
 
         // check if each word in sentence_to_tag's corresponding tag is in its corresponding tag vector in words_to_tags
         let all_tags_valid = sentence_to_tag.iter().all(|(word, tag)| {
-            if let Some(possible_tags) = possible_tags.iter().find(|(w, _)| *w == *word) {
-                possible_tags.1.contains(tag)
+            if let Some(possible_tags) = possible_tags.iter().find(|(w, _)| w == word)  {
+                // The assigned tag must be in the word's possible tags.
+                // If the word can be ANY, then any tag is valid.
+                // The tag CANNOT be ANY (this means it is unassigned).
+                (possible_tags.1.contains(tag) || possible_tags.1.contains(&Wordclass::ANY)) && *tag != Wordclass::ANY
             } else {
                 false
             }
@@ -100,7 +103,7 @@ fn tokenize_sentence(sentence: &str) -> Vec<String> {
         .collect()
 }
 
-/// Given a tokenized `sentence` and mapping `wc_mapping`, retrieve the possible tags for each word.
+/// Function to: given a tokenized `sentence` and mapping `wc_mapping`, retrieve the possible tags for each word.
 fn get_possible_tags(sentence: Vec<String>, wc_mapping: &mut WordclassMap) -> Vec<(String, Vec<Wordclass>)> {
     sentence.iter()
         .map(|word| (word.as_str().to_owned(), wc_mapping.entry(word.as_str().parse().unwrap()).or_insert(vec![Wordclass::ANY]).to_owned()))
@@ -116,5 +119,5 @@ fn retrieve_sentence_to_tag(sentence: Vec<(String, Vec<Wordclass>)>) -> Vec<(Str
 
 #[test]
 fn test_tag_sentence() {
-    tag_sentence("it's asjdlh");
+    tag_sentence("i wanna rock and roll all night and party every day alshjjhsb");
 }

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -4,6 +4,7 @@ use crate::rs_contextual_ruleset::parse_contextual_ruleset;
 use crate::rs_contextual_rulespec::{contextual_rule_apply, ContextualRulespec};
 use crate::rs_wordclass::Wordclass;
 use crate::{initialize_tagger, WordclassMap};
+use crate::rs_contractions::find_contractions;
 
 fn tag_sentence(sentence: &str) {
     //let lexical_ruleset: Vec<LexicalRulespec> = parse_lexical_ruleset("data/rulefile_lexical.txt").unwrap();
@@ -13,11 +14,12 @@ fn tag_sentence(sentence: &str) {
 
     println!("sentence: {}\n", sentence);
 
+    let tokenised_sentence: Vec<String> = sentence.split_whitespace().map(|word|find_contractions(String::from(word)).unwrap()).flatten().collect();
+    println!("tokenised sentence: {:?}", tokenised_sentence);
+
     // Match each word with its list of possible tags
-    let words_to_tags: Vec<(&str, Vec<Wordclass>)> = sentence
-        .split_whitespace()
-        .enumerate()
-        .map(|(_, word)| (word, wc_mapping.get(word).ok_or(format!("Word not in lexicon: {}", word)).unwrap().to_owned()))
+    let words_to_tags: Vec<(&str, Vec<Wordclass>)> = tokenised_sentence.iter()
+        .map(|(word)| (word.as_str(), wc_mapping.get(word.as_str()).ok_or(format!("Word not in lexicon: {}", word)).unwrap().to_owned()))
         .collect();
 
     println!("possible tags: {:?}\n", words_to_tags);
@@ -74,6 +76,6 @@ fn tag_sentence(sentence: &str) {
 
 #[test]
 fn test_tag_sentence() {
-    tag_sentence("It is now some years since I detected how many were the false
+    tag_sentence("it's now some years since I detected how many were the false
 beliefs that I had from my earliest youth admitted as true");
 }

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -12,7 +12,7 @@ use crate::rs_lexical_rulespec::lexical_rule_apply;
 fn tag_sentence(sentence: &str) {
     //let lexical_ruleset: Vec<LexicalRulespec> = parse_lexical_ruleset("data/rulefile_lexical.txt").unwrap();
     let contextual_ruleset: HashMap<Wordclass, Vec<ContextualRulespec>> = parse_contextual_ruleset("data/rulefile_contextual.txt").unwrap();
-    let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
+    let mut wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
 
     println!("sentence: {}\n", sentence);
 
@@ -20,7 +20,7 @@ fn tag_sentence(sentence: &str) {
     println!("tokenised sentence: {:?}", tokenised_sentence);
 
     // Match each word with its list of possible tags
-    let words_to_tags: Vec<(String, Vec<Wordclass>)> = get_possible_tags(tokenised_sentence, &wc_mapping);
+    let words_to_tags: Vec<(String, Vec<Wordclass>)> = get_possible_tags(tokenised_sentence, &mut wc_mapping);
     println!("possible tags: {:?}\n", words_to_tags);
 
     // Create a vector of tuples: strings to the first element in the list
@@ -101,9 +101,9 @@ fn tokenize_sentence(sentence: &str) -> Vec<String> {
 }
 
 /// Given a tokenized `sentence` and mapping `wc_mapping`, retrieve the possible tags for each word.
-fn get_possible_tags(sentence: Vec<String>, wc_mapping: &WordclassMap) -> Vec<(String, Vec<Wordclass>)> {
+fn get_possible_tags(sentence: Vec<String>, wc_mapping: &mut WordclassMap) -> Vec<(String, Vec<Wordclass>)> {
     sentence.iter()
-        .map(|word| (word.as_str().to_owned(), wc_mapping.get(word.as_str()).ok_or(format!("Word not in lexicon: {}", word)).unwrap().to_owned()))
+        .map(|word| (word.as_str().to_owned(), wc_mapping.entry(word.as_str().parse().unwrap()).or_insert(vec![Wordclass::ANY]).to_owned()))
         .collect()
 }
 
@@ -116,6 +116,5 @@ fn retrieve_sentence_to_tag(sentence: Vec<(String, Vec<Wordclass>)>) -> Vec<(Str
 
 #[test]
 fn test_tag_sentence() {
-    tag_sentence("it's now some years since I detected how many were the false
-beliefs that I had from my earliest youth admitted as true");
+    tag_sentence("it's asjdlh");
 }

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -10,43 +10,22 @@ use crate::rs_lexical_ruleset::parse_lexical_ruleset;
 //use crate::rs_lexical_ruleset::parse_lexical_ruleset;
 use crate::rs_lexical_rulespec::lexical_rule_apply;
 
-fn tag_sentence(sentence: &str) -> bool {
+
+/// Function to tag a `sentence` using lexical and contextual rules.
+fn tag_sentence(sentence: &str) {
+    // Parse rulesets and lexicon.
     let lexical_ruleset: Vec<LexicalRulespec> = parse_lexical_ruleset("data/rulefile_lexical.txt").unwrap();
     let contextual_ruleset: HashMap<Wordclass, Vec<ContextualRulespec>> = parse_contextual_ruleset("data/rulefile_contextual.txt").unwrap();
     let mut wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
 
-    println!("sentence: {}\n", sentence);
-
+    // Tokenise sentence, and map each word to its possible tags.
     let tokenised_sentence = tokenize_sentence(sentence);
-    println!("tokenised sentence: {:?}", tokenised_sentence);
-
-    // Match each word with its list of possible tags
     let words_to_tags: Vec<(String, Vec<Wordclass>)> = get_possible_tags(tokenised_sentence, &mut wc_mapping);
-    println!("possible tags: {:?}\n", words_to_tags);
-
-    // Create a vector of tuples: strings to the first element in the list
     let mut sentence_to_tag: Vec<(String, Wordclass)> = retrieve_sentence_to_tag(words_to_tags.clone());
-    println!("sentence to tag: {:?}", sentence_to_tag);
 
-    // Apply lexical rules.
-    println!("applying lexical rules\n");
+    // Apply lexical and contextual rules.
     apply_lexical_rules(&mut sentence_to_tag, &lexical_ruleset, &words_to_tags, &wc_mapping);
-
-    // Apply contextual rules.
-    println!("applying contextual rules:\n");
-    let result = apply_contextual_rules(&mut sentence_to_tag, &words_to_tags, &contextual_ruleset, 100);
-
-    match result {
-        Ok(_) => {}
-        Err(_) => {
-            println!("max iterations reached");
-            return false;}
-    }
-
-    println!("final sentence: {:?}", sentence_to_tag);
-
-    return true;
-
+    apply_contextual_rules(&mut sentence_to_tag, &words_to_tags, &contextual_ruleset, 100).ok_or("Max iterations reached in contextual rules");
 }
 
 
@@ -54,23 +33,15 @@ fn tag_sentence(sentence: &str) -> bool {
 fn apply_lexical_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, lexical_ruleset: &Vec<LexicalRulespec>, possible_tags: &Vec<(String, Vec<Wordclass>)>, wc_mapping: &WordclassMap) {
     for (index, (word, _)) in enumerate(sentence_to_tag.clone()) {
         for rule in lexical_ruleset {
-
             if !is_tag_contained_in_word_possible_tags(&possible_tags, &word, &rule.target_tag) {continue;}
-
-            match lexical_rule_apply(sentence_to_tag, index as i32, rule, wc_mapping) {
-                Some(true) => {
-                    println!("RuleLexical (word {:?} -> {} if {} passes with parameters {:?})", &sentence_to_tag.get(index), rule.target_tag, rule.ruleset_id, rule.parameters);
-                }
-                _ => {}
-            }
+            lexical_rule_apply(sentence_to_tag, index as i32, rule, wc_mapping);
         }
     }
 }
 
 
 /// Continuously apply contextual rules to a sentence `sentence_to_tag` until each word's tag is in `possible_tags` or no rules were applied.
-fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possible_tags: &Vec<(String, Vec<Wordclass>)>, contextual_ruleset: &HashMap<Wordclass, Vec<ContextualRulespec>>, threshold:i32) -> Result<String, String> {
-
+fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possible_tags: &Vec<(String, Vec<Wordclass>)>, contextual_ruleset: &HashMap<Wordclass, Vec<ContextualRulespec>>, threshold:i32) -> Option<bool> {
     let mut iterations = 0;
     loop {
         for (index, (word, tag)) in enumerate(sentence_to_tag.clone()) {
@@ -78,43 +49,21 @@ fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possib
             match valid_rules {
                 Some(_valid_rules) => {
                     for rule in _valid_rules {
-
                         if !is_tag_contained_in_word_possible_tags(possible_tags, &word, &rule.target_tag) {continue;}
-
-                        match contextual_rule_apply(sentence_to_tag, index as i32, rule.clone()) {
-                            Some(true) => {
-                                println!("RuleContextual (word {:?} with tag {:?} -> {:?} if {} passes with parameters {:?})", &sentence_to_tag.get(index).unwrap().0, tag, rule.target_tag, rule.ruleset_id, rule.parameters);
-                            }
-                            _ => {}
-                        }
+                        contextual_rule_apply(sentence_to_tag, index as i32, rule.clone());
                     }
                 }
-                None => continue // some Wordclasses have no associated rules (e.g. CC). In this case, the tag is kept.
+                // Some Wordclasses have no associated rules (e.g. CC) - in this case, the tag is kept.
+                None => continue
             }
-
-
-
         }
-
-        // check if each word in sentence_to_tag's corresponding tag is in its corresponding tag vector in words_to_tags
-        let all_tags_valid = sentence_to_tag.iter().all(|(word, tag)| {
-            if let Some(possible_tags) = possible_tags.iter().find(|(w, _)| w == word)  {
-                // The assigned tag must be in the word's possible tags.
-                // If the word can be ANY, then any tag is valid.
-                // The tag CANNOT be ANY (this means it is unassigned).
-                (possible_tags.1.contains(tag) || possible_tags.1.contains(&Wordclass::ANY)) && *tag != Wordclass::ANY
-            } else {
-                false
-            }
-        });
-        if all_tags_valid {return Ok(String::from("Sentence is valid"))}
-
-        if(iterations == threshold) {return Err(String::from("Number of iterations exceeded in contextual rules."));}
-
+        if are_tags_valid(&sentence_to_tag, &possible_tags) {return Some(true)}
+        if(iterations == threshold) {return None;}
         iterations +=1;
     }
 
 }
+
 
 /// Function to take a `sentence` (&str), split whitespace and tokenize any contractions.
 fn tokenize_sentence(sentence: &str) -> Vec<String> {
@@ -124,12 +73,14 @@ fn tokenize_sentence(sentence: &str) -> Vec<String> {
         .collect()
 }
 
+
 /// Function to: given a tokenized `sentence` and mapping `wc_mapping`, retrieve the possible tags for each word.
 fn get_possible_tags(sentence: Vec<String>, wc_mapping: &mut WordclassMap) -> Vec<(String, Vec<Wordclass>)> {
     sentence.iter()
         .map(|word| (word.as_str().to_owned(), wc_mapping.entry(word.as_str().parse().unwrap()).or_insert(vec![Wordclass::ANY]).to_owned()))
         .collect()
 }
+
 
 /// Function to alter the first tag of the word's possible tags. Retrieve this tag for each word.
 fn retrieve_sentence_to_tag(sentence: Vec<(String, Vec<Wordclass>)>) -> Vec<(String, Wordclass)> {
@@ -138,16 +89,34 @@ fn retrieve_sentence_to_tag(sentence: Vec<(String, Vec<Wordclass>)>) -> Vec<(Str
         .filter_map(|(word, tags)| tags.first().map(|first_tag| (word.to_owned(), first_tag.clone()))).collect()
 }
 
+
 /// Function to check if `possible_tag`s of a given `word` contain `target_tag`.
 fn is_tag_contained_in_word_possible_tags(possible_tags: &Vec<(String, Vec<Wordclass>)>, word: &String, target_tag: &Wordclass) -> bool {
     let possible_tags_for_word =     possible_tags.iter()
-        .find(|(first, _)| first == word) // Find the tuple where the first element matches `key`
-        .map(|(_, second)| second).unwrap(); // Map to the second element
+        .find(|(first, _)| first == word)
+        .map(|(_, second)| second).unwrap();
 
     possible_tags_for_word.contains(target_tag)
 }
+
+
+/// Function to check if all tags in a `sentence` are contained in their list of `possible_tags`.
+fn are_tags_valid(sentence: &Vec<(String, Wordclass)>, possible_tags: &Vec<(String, Vec<Wordclass>)>) -> bool {
+    sentence.iter().all(|(word, tag)| {
+        possible_tags
+            .iter()
+            .find(|(w, _)| w == word)
+            .map_or(false, |(_, tags)|
+
+                // This asserts, that for each word in the sentence, the assigned `tag` must exist in
+                // the lexicon entry for the `word`. If the words lexicon entry contains `Wordclass::ANY`
+                // then any tag is valid. Additionally, the final tag itself cannot be `Wordclass::ANY`.
+                (tags.contains(tag) || tags.contains(&Wordclass::ANY)) && *tag != Wordclass::ANY)
+    })
+}
+
 #[test]
 fn test_tag_sentence() {
-    assert!(tag_sentence("i want to rock and roll every night"));
-    //assert!(tag_sentence("the quick fox jumped over the lazy dog"))
+    // To do proper tests, need to know what the sentences should be tagged as!
+    tag_sentence("i want to rock and roll every night");
 }

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -58,7 +58,7 @@ fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possib
             }
         }
         if are_tags_valid(&sentence_to_tag, &possible_tags) {return Some(true)}
-        if(iterations == threshold) {return None;}
+        if iterations == threshold {return None;}
         iterations +=1;
     }
 

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -5,37 +5,49 @@ use crate::rs_contextual_rulespec::{contextual_rule_apply, ContextualRulespec};
 use crate::rs_wordclass::Wordclass;
 use crate::{initialize_tagger, WordclassMap};
 use crate::rs_contractions::find_contractions;
+use crate::rs_lex_rulespec_id::LexicalRulespec;
+use crate::rs_lexical_ruleset::parse_lexical_ruleset;
+use crate::rs_lexical_rulespec::lexical_rule_holds;
 
 fn tag_sentence(sentence: &str) {
-    //let lexical_ruleset: Vec<LexicalRulespec> = parse_lexical_ruleset("data/rulefile_lexical.txt").unwrap();
+    let lexical_ruleset: Vec<LexicalRulespec> = parse_lexical_ruleset("data/rulefile_lexical.txt").unwrap();
     let contextual_ruleset: HashMap<Wordclass, Vec<ContextualRulespec>> = parse_contextual_ruleset("data/rulefile_contextual.txt").unwrap();
 
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
 
     println!("sentence: {}\n", sentence);
 
-    let tokenised_sentence: Vec<String> = sentence.split_whitespace().
-        map(|word|find_contractions(String::from(word))
-            .unwrap())
-        .flatten()
-        .collect();
-
+    let tokenised_sentence = tokenize_sentence(sentence);
     println!("tokenised sentence: {:?}", tokenised_sentence);
 
     // Match each word with its list of possible tags
-    let words_to_tags: Vec<(&str, Vec<Wordclass>)> = tokenised_sentence.iter()
-        .map(|(word)| (word.as_str(), wc_mapping.get(word.as_str()).ok_or(format!("Word not in lexicon: {}", word)).unwrap().to_owned()))
-        .collect();
+    let words_to_tags: Vec<(String, Vec<Wordclass>)> = get_possible_tags(tokenised_sentence, &wc_mapping);
 
     println!("possible tags: {:?}\n", words_to_tags);
 
     // Create a vector of tuples: strings to the first element in the list
-    let mut sentence_to_tag: Vec<(&str, Wordclass)> = words_to_tags
+    let mut sentence_to_tag: Vec<(String, Wordclass)> = words_to_tags
         .iter()
-        .filter_map(|(word, tags)| tags.first().map(|first_tag| (*word, first_tag.clone())))
+        .filter_map(|(word, tags)| tags.first().map(|first_tag| (word.to_owned(), first_tag.clone())))
         .collect();
 
     println!("sentence to tag: {:?}", sentence_to_tag);
+
+    // LEXICAL RULES
+
+    println!("applying lexical rules\n");
+
+    //let rules_applied = 0;
+    for (index, (_, _)) in enumerate(sentence_to_tag.clone()) {
+        for rule in &lexical_ruleset {
+            match lexical_rule_holds(&mut sentence_to_tag.clone(), index as i32, rule, &wc_mapping) {
+                Some(true) => {
+
+                }
+                _ => {}
+            }
+        }
+    }
 
 
     println!("valid contextual rules:\n");
@@ -73,10 +85,28 @@ fn tag_sentence(sentence: &str) {
         if all_tags_valid || rules_applied == 0 {break;}
 
 
+
+
+
     }
 
     println!("final sentence: {:?}", sentence_to_tag);
 
+}
+
+
+/// Function to take a `sentence` (&str), split whitespace and tokenize any contractions.
+fn tokenize_sentence(sentence: &str) -> Vec<String> {
+    sentence.split_whitespace().
+        map(|word|find_contractions(String::from(word)).unwrap())
+        .flatten()
+        .collect()
+}
+
+fn get_possible_tags(sentence: Vec<String>, wc_mapping: &WordclassMap) -> Vec<(String, Vec<Wordclass>)> {
+    sentence.iter()
+        .map(|word| (word.as_str().to_owned(), wc_mapping.get(word.as_str()).ok_or(format!("Word not in lexicon: {}", word)).unwrap().to_owned()))
+        .collect()
 }
 
 #[test]

--- a/src/rs_brill_tagger.rs
+++ b/src/rs_brill_tagger.rs
@@ -9,7 +9,7 @@ use crate::rs_lex_rulespec_id::LexicalRulespec;
 //use crate::rs_lexical_ruleset::parse_lexical_ruleset;
 use crate::rs_lexical_rulespec::lexical_rule_apply;
 
-fn tag_sentence(sentence: &str) {
+fn tag_sentence(sentence: &str) -> bool {
     //let lexical_ruleset: Vec<LexicalRulespec> = parse_lexical_ruleset("data/rulefile_lexical.txt").unwrap();
     let contextual_ruleset: HashMap<Wordclass, Vec<ContextualRulespec>> = parse_contextual_ruleset("data/rulefile_contextual.txt").unwrap();
     let mut wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
@@ -33,9 +33,17 @@ fn tag_sentence(sentence: &str) {
 
     // Apply contextual rules.
     println!("applying contextual rules:\n");
-    apply_contextual_rules(&mut sentence_to_tag, &words_to_tags, &contextual_ruleset);
+    let result = apply_contextual_rules(&mut sentence_to_tag, &words_to_tags, &contextual_ruleset, 100);
+
+    match result {
+        Ok(_) => {}
+        Err(_) => {
+            return false;}
+    }
 
     println!("final sentence: {:?}", sentence_to_tag);
+
+    return true;
 
 }
 
@@ -57,9 +65,10 @@ fn apply_lexical_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, lexical_r
 
 
 /// Continuously apply contextual rules to a sentence `sentence_to_tag` until each word's tag is in `possible_tags` or no rules were applied.
-fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possible_tags: &Vec<(String, Vec<Wordclass>)>, contextual_ruleset: &HashMap<Wordclass, Vec<ContextualRulespec>>) {
+fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possible_tags: &Vec<(String, Vec<Wordclass>)>, contextual_ruleset: &HashMap<Wordclass, Vec<ContextualRulespec>>, threshold:i32) -> Result<String, String> {
+
+    let mut iterations = 0;
     loop {
-        let mut rules_applied = 0;
         for (index, (_, tag)) in enumerate(sentence_to_tag.clone()) {
             let valid_rules = contextual_ruleset.get(&tag);
             match valid_rules {
@@ -70,13 +79,14 @@ fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possib
                             Some(false) => {}
                             Some(true) => {
                                 println!("RuleContextual (word {:?} -> {} if {} passes with parameters {:?})", &sentence_to_tag.get(index), rule.target_tag, rule.ruleset_id, rule.parameters);
-                                rules_applied +=1;
                             }
                         }
                     }
                 }
                 None => continue // some Wordclasses have no associated rules (e.g. CC). In this case, the tag is kept.
             }
+
+
 
         }
 
@@ -91,8 +101,13 @@ fn apply_contextual_rules(sentence_to_tag: &mut Vec<(String, Wordclass)>, possib
                 false
             }
         });
-        if all_tags_valid || rules_applied == 0 {break;}
-        }
+        if all_tags_valid {return Ok(String::from("Sentence is valid"))}
+
+        if(iterations == threshold) {return Err(String::from("Number of iterations exceeded in contextual rules."));}
+
+        iterations +=1;
+    }
+
 }
 
 /// Function to take a `sentence` (&str), split whitespace and tokenize any contractions.
@@ -119,5 +134,6 @@ fn retrieve_sentence_to_tag(sentence: Vec<(String, Vec<Wordclass>)>) -> Vec<(Str
 
 #[test]
 fn test_tag_sentence() {
-    tag_sentence("i wanna rock and roll all night and party every day alshjjhsb");
+    assert!(!tag_sentence("i wanna rock and roll all night and party every alsdhasbd"));
+    assert!(tag_sentence("the quick fox jumped over the lazy dog"))
 }

--- a/src/rs_contextual_rulespec.rs
+++ b/src/rs_contextual_rulespec.rs
@@ -4,7 +4,7 @@ use crate::rs_wordclass::{map_pos_tag, Wordclass};
 
 
 /// Function to check if the tag at index - 1 is equal to `tag` in a sentence.
-pub fn previous_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
+pub fn previous_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
     match sentence.get((current_index - 1) as usize) {
         Some((_, ref _tag)) if _tag == &tag => true,
         _ => false,
@@ -13,7 +13,7 @@ pub fn previous_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: W
 
 
 /// Function to check if the tag at index - 1 is equal to `tag` in a sentence.
-pub fn next_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
+pub fn next_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
     match sentence.get((current_index + 1) as usize) {
         Some((_, ref _tag)) if _tag == &tag => true,
         _ => false,
@@ -22,7 +22,7 @@ pub fn next_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: Wordc
 
 
 /// Function to check if the word at index - 1 is equal to `word` in a sentence.
-pub fn previous_word(sentence: Vec<(&str, Wordclass)>, current_index: i32, word: &str) -> bool {
+pub fn previous_word(sentence: Vec<(String, Wordclass)>, current_index: i32, word: &str) -> bool {
     match sentence.get((current_index - 1) as usize) {
         Some((_word, _)) if _word == &word => true,
         _ => false,
@@ -31,7 +31,7 @@ pub fn previous_word(sentence: Vec<(&str, Wordclass)>, current_index: i32, word:
 
 
 /// Function to check if the tag at index +1 or index +2 is equal to `tag` in a sentence.
-pub fn next_one_or_two_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
+pub fn next_one_or_two_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
     (1..=2).any(|offset| {
         sentence.get((current_index + offset) as usize).map_or(false, |&(_, ref _tag)| _tag == &tag)
     })
@@ -39,7 +39,7 @@ pub fn next_one_or_two_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32,
 
 
 /// Function to check if the tag at index - 1 or index - 2 is equal to `tag` in a sentence.
-pub fn previous_one_or_two_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
+pub fn previous_one_or_two_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
     (1..=2).any(|offset| {
         sentence.get((current_index - offset) as usize).map_or(false, |&(_, ref _tag)| _tag == &tag)
     })
@@ -47,7 +47,7 @@ pub fn previous_one_or_two_tag(sentence: Vec<(&str, Wordclass)>, current_index: 
 
 
 /// Function to check if the word at index - 1 or index - 2 or index - 3 is equal to `tag` in a sentence.
-pub fn previous_one_or_two_or_three_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
+pub fn previous_one_or_two_or_three_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
     (1..=3).any(|offset| {
         sentence.get((current_index - offset) as usize).map_or(false, |&(_, ref _tag)| _tag == &tag)
     })
@@ -55,13 +55,13 @@ pub fn previous_one_or_two_or_three_tag(sentence: Vec<(&str, Wordclass)>, curren
 
 
 /// Function to check if the tag at index +1, +2 or +3 is equal to `tag` in a sentence.
-pub fn next_one_or_two_or_three_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
+pub fn next_one_or_two_or_three_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
     sentence.iter().skip((current_index + 1) as usize).take(3).any(|(_, t)| *t == tag)
 }
 
 
 /// Function to check current word, and tag 2 words after.
-pub fn word_and_tag_2_after(sentence: Vec<(&str, Wordclass)>, current_index: i32, word: &str, tag: Wordclass) -> bool {
+pub fn word_and_tag_2_after(sentence: Vec<(String, Wordclass)>, current_index: i32, word: &str, tag: Wordclass) -> bool {
     if sentence.get(current_index as usize).map_or(false, |(w, _)| w == &word) {
         sentence.get(current_index as usize + 2).map_or(false, |(_, t)| *t == tag)
     } else { false }
@@ -69,7 +69,7 @@ pub fn word_and_tag_2_after(sentence: Vec<(&str, Wordclass)>, current_index: i32
 
 
 /// Function to check current word, and word 2 words after.
-pub fn word_and_2_after(sentence: Vec<(&str, Wordclass)>, current_index: i32, word_one: &str, word_two: &str) -> bool {
+pub fn word_and_2_after(sentence: Vec<(String, Wordclass)>, current_index: i32, word_one: &str, word_two: &str) -> bool {
     if sentence.get(current_index as usize).map_or(false, |(w1, _)| w1 == &word_one) {
         sentence.get((current_index + 2) as usize).map_or(false, |(w2, _)| w2 == &word_two)
     } else { false }
@@ -77,15 +77,15 @@ pub fn word_and_2_after(sentence: Vec<(&str, Wordclass)>, current_index: i32, wo
 
 
 /// Function to check if the word at index - 1 or index - 2 is equal to `word` in a sentence.
-pub fn previous_one_or_two_word(sentence: Vec<(&str, Wordclass)>, current_index: i32, word: &str) -> bool {
+pub fn previous_one_or_two_word(sentence: Vec<(String, Wordclass)>, current_index: i32, word: &str) -> bool {
     (1..=2).any(|offset| {
-        sentence.get((current_index - offset) as usize).map_or(false, |&(_word, _)| _word == word)
+        sentence.get((current_index - offset) as usize).map_or(false, |(_word, _)| _word == word)
     })
 }
 
 
 /// Function to check if the tag at index - 2 is equal to `tag` in a sentence.
-pub fn prev_two_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
+pub fn prev_two_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, tag: Wordclass) -> bool {
     match sentence.get((current_index - 2) as usize) {
         Some((_, ref _tag)) if _tag == &tag => true,
         _ => false,
@@ -94,7 +94,7 @@ pub fn prev_two_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag: W
 
 
 /// Function to check if the word at index + 1 is equal to `word` in a sentence.
-pub fn next_word (sentence: Vec<(&str, Wordclass)>, current_index: i32, word: &str) -> bool {
+pub fn next_word (sentence: Vec<(String, Wordclass)>, current_index: i32, word: &str) -> bool {
     match sentence.get((current_index - 1) as usize) {
         Some((_word, _)) if _word == &word => true,
         _ => false,
@@ -103,7 +103,7 @@ pub fn next_word (sentence: Vec<(&str, Wordclass)>, current_index: i32, word: &s
 
 
 /// Function to check current word and tag of hte next word.
-pub fn word_and_next_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, word_one: &str, next_tag: Wordclass) -> bool {
+pub fn word_and_next_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, word_one: &str, next_tag: Wordclass) -> bool {
     if sentence.get(current_index as usize).map_or(false, |(w1, _)| w1 == &word_one) {
         sentence.get(current_index as usize + 2).map_or(false, |(_, _tag)| _tag == &next_tag)
     } else { false }
@@ -111,7 +111,7 @@ pub fn word_and_next_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, w
 
 
 /// Function to check the surrounding tags of a word.
-pub fn surrounding_tags(sentence: Vec<(&str, Wordclass)>, current_index: i32, previous_tag: Wordclass, next_tag: Wordclass) -> bool {
+pub fn surrounding_tags(sentence: Vec<(String, Wordclass)>, current_index: i32, previous_tag: Wordclass, next_tag: Wordclass) -> bool {
     match sentence.get((current_index  - 1) as usize) {
         Some((_, ref _tag)) if _tag == &previous_tag => match sentence.get((current_index + 1) as usize) {
             Some((_, ref _tag)) if _tag == &next_tag => true,
@@ -123,7 +123,7 @@ pub fn surrounding_tags(sentence: Vec<(&str, Wordclass)>, current_index: i32, pr
 
 
 /// Function to check current word and tag of hte next word.
-pub fn word_and_two_tag_before(sentence: Vec<(&str, Wordclass)>, current_index: i32, word: &str, tag: Wordclass) -> bool {
+pub fn word_and_two_tag_before(sentence: Vec<(String, Wordclass)>, current_index: i32, word: &str, tag: Wordclass) -> bool {
     if sentence.get(current_index as usize).map_or(false, |(w1, _)| w1 == &word) {
         sentence.get(current_index as usize - 2).map_or(false, |(_, _tag)| _tag == &tag)
     } else { false }
@@ -132,7 +132,7 @@ pub fn word_and_two_tag_before(sentence: Vec<(&str, Wordclass)>, current_index: 
 
 
 /// Function to check a right-bigram.
-pub fn right_bigram(sentence: Vec<(&str, Wordclass)>, current_index: i32, word_one: &str, word_two: &str) -> bool {
+pub fn right_bigram(sentence: Vec<(String, Wordclass)>, current_index: i32, word_one: &str, word_two: &str) -> bool {
     if sentence.get(current_index as usize).map_or(false, |(w1, _)| w1 == &word_one) {
         sentence.get((current_index + 1) as usize).map_or(false, |(w2, _)| w2 == &word_two)
     } else { false }
@@ -141,7 +141,7 @@ pub fn right_bigram(sentence: Vec<(&str, Wordclass)>, current_index: i32, word_o
 
 
 /// Function to check a left-bigram.
-pub fn left_bigram(sentence: Vec<(&str, Wordclass)>, current_index: i32, word_one: &str, word_two: &str) -> bool {
+pub fn left_bigram(sentence: Vec<(String, Wordclass)>, current_index: i32, word_one: &str, word_two: &str) -> bool {
     if sentence.get(current_index as usize).map_or(false, |(w1, _)| w1 == &word_one) {
         sentence.get((current_index - 1) as usize).map_or(false, |(w2, _)| w2 == &word_two)
     } else { false }
@@ -149,7 +149,7 @@ pub fn left_bigram(sentence: Vec<(&str, Wordclass)>, current_index: i32, word_on
 
 
 /// Function to check previous bigram tags
-pub fn prev_bigram(sentence: Vec<(&str, Wordclass)>, current_index: i32, class_one: Wordclass, class_two: Wordclass) -> bool {
+pub fn prev_bigram(sentence: Vec<(String, Wordclass)>, current_index: i32, class_one: Wordclass, class_two: Wordclass) -> bool {
     if sentence.get((current_index - 1) as usize).map_or(false, |(_, tag1)| tag1 == &class_one) {
         sentence.get((current_index - 2) as usize ).map_or(false, |(_, tag2)| tag2 == &class_two)
     } else { false }
@@ -158,7 +158,7 @@ pub fn prev_bigram(sentence: Vec<(&str, Wordclass)>, current_index: i32, class_o
 
 
 /// Function to check the next bigram tags
-pub fn next_bigram(sentence: Vec<(&str, Wordclass)>, current_index: i32, class_one: Wordclass, class_two: Wordclass) -> bool {
+pub fn next_bigram(sentence: Vec<(String, Wordclass)>, current_index: i32, class_one: Wordclass, class_two: Wordclass) -> bool {
     if sentence.get(current_index as usize + 1).map_or(false, |(_, tag1)| tag1 == &class_one) {
         sentence.get(current_index as usize + 2).map_or(false, |(_, tag2)| tag2 == &class_two)
     } else { false }
@@ -167,7 +167,7 @@ pub fn next_bigram(sentence: Vec<(&str, Wordclass)>, current_index: i32, class_o
 
 
 /// Function to check a left-bigram.
-pub fn current_word(sentence: Vec<(&str, Wordclass)>, current_index: i32, word: &str) -> bool {
+pub fn current_word(sentence: Vec<(String, Wordclass)>, current_index: i32, word: &str) -> bool {
     if sentence.get(current_index as usize).map_or(false, |(w1, _)| w1 == &word) { true }
     else { false }
 }
@@ -175,7 +175,7 @@ pub fn current_word(sentence: Vec<(&str, Wordclass)>, current_index: i32, word: 
 
 
 /// Function to check word and previous tag
-pub fn word_and_previous_tag(sentence: Vec<(&str, Wordclass)>, current_index: i32, word: &str, tag: Wordclass) -> bool {
+pub fn word_and_previous_tag(sentence: Vec<(String, Wordclass)>, current_index: i32, word: &str, tag: Wordclass) -> bool {
     if sentence.get(current_index as usize).map_or(false, |(w1, _)| w1 == &word) {
         sentence.get(current_index as usize - 1).map_or(false, |(_, _tag)| _tag == &tag)
     } else { false }
@@ -184,7 +184,7 @@ pub fn word_and_previous_tag(sentence: Vec<(&str, Wordclass)>, current_index: i3
 
 
 /// Function to check word and previous tag
-pub fn next_two_tags(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag1: Wordclass) -> bool {
+pub fn next_two_tags(sentence: Vec<(String, Wordclass)>, current_index: i32, tag1: Wordclass) -> bool {
     if sentence.get((current_index + 2) as usize).map_or(false, |(_, _tag1)| _tag1 == &tag1) { true }
     else { false }
 }
@@ -192,7 +192,7 @@ pub fn next_two_tags(sentence: Vec<(&str, Wordclass)>, current_index: i32, tag1:
 
 
 // Checks a given contextual rule.
-pub fn contextual_rule_holds(sentence: Vec<(&str, Wordclass)>, current_index: i32, rule: ContextualRulespec) -> Option<bool> {
+pub fn contextual_rule_holds(sentence: Vec<(String, Wordclass)>, current_index: i32, rule: ContextualRulespec) -> Option<bool> {
 
     match rule.ruleset_id {
 
@@ -385,7 +385,7 @@ pub fn contextual_rule_holds(sentence: Vec<(&str, Wordclass)>, current_index: i3
 
 
 
-pub fn contextual_rule_apply(sentence: &mut Vec<(&str, Wordclass)>, current_index: i32, rule: ContextualRulespec) -> Option<bool> {
+pub fn contextual_rule_apply(sentence: &mut Vec<(String, Wordclass)>, current_index: i32, rule: ContextualRulespec) -> Option<bool> {
     // Check if Contextual Rule can be run
     let uindex: usize = current_index as usize;
     let check_pair = sentence.get(uindex)?;
@@ -397,7 +397,7 @@ pub fn contextual_rule_apply(sentence: &mut Vec<(&str, Wordclass)>, current_inde
     match contextual_rule_holds(sentence.to_owned(), current_index, rule.clone()) {
         Some(true) => {
             let new_tag = rule.clone().target_tag;
-            sentence[uindex] = (sentence[uindex].0, new_tag);
+            sentence[uindex].1 = new_tag;
             Option::from(true)
         }
         _ => Option::from(false),
@@ -428,10 +428,10 @@ impl fmt::Display for ContextualRulespec {
 #[test]
 fn test_contextual_rule() {
     let mut sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
 
     let rule: ContextualRulespec = ContextualRulespec {
@@ -455,10 +455,10 @@ fn test_contextual_rule() {
 #[test]
 fn test_previous_one_or_two_tag_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(previous_one_or_two_tag(sentence.clone(), 3, Wordclass::JJ));
     assert!(previous_one_or_two_tag(sentence.clone(), 4, Wordclass::JJ));
@@ -469,10 +469,10 @@ fn test_previous_one_or_two_tag_found() {
 #[test]
 fn test_previous_one_or_two_tag_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!previous_one_or_two_tag(sentence.clone(), 2, Wordclass::NN));
     assert!(!previous_one_or_two_tag(sentence.clone(), 1, Wordclass::NN));
@@ -483,8 +483,8 @@ fn test_previous_one_or_two_tag_not_found() {
 #[test]
 fn test_previous_one_or_two_tag_out_of_bounds() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
     ];
     assert!(!previous_one_or_two_tag(sentence.clone(), 1, Wordclass::NN));
     assert!(!previous_one_or_two_tag(sentence.clone(), 0, Wordclass::DT));
@@ -495,11 +495,11 @@ fn test_previous_one_or_two_tag_out_of_bounds() {
 #[test]
 fn test_previous_one_or_two_or_three_tag_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("lazy", Wordclass::JJ),
-        ("dog", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(previous_one_or_two_or_three_tag(sentence.clone(), 4, Wordclass::JJ));
     assert!(previous_one_or_two_or_three_tag(sentence.clone(), 5, Wordclass::JJ));
@@ -510,11 +510,11 @@ fn test_previous_one_or_two_or_three_tag_found() {
 #[test]
 fn test_previous_one_or_two_or_three_tag_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("lazy", Wordclass::JJ),
-        ("dog", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!previous_one_or_two_or_three_tag(sentence.clone(), 3, Wordclass::NN));
     assert!(!previous_one_or_two_or_three_tag(sentence.clone(), 2, Wordclass::NN));
@@ -525,8 +525,8 @@ fn test_previous_one_or_two_or_three_tag_not_found() {
 #[test]
 fn test_previous_one_or_two_or_three_tag_out_of_bounds() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
     ];
     assert!(!previous_one_or_two_or_three_tag(sentence.clone(), 1, Wordclass::NN));
     assert!(!previous_one_or_two_or_three_tag(sentence.clone(), 0, Wordclass::DT));
@@ -537,11 +537,11 @@ fn test_previous_one_or_two_or_three_tag_out_of_bounds() {
 #[test]
 fn test_next_one_or_two_or_three_tag_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("lazy", Wordclass::JJ),
-        ("dog", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(next_one_or_two_or_three_tag(sentence.clone(), 1, Wordclass::JJ));
     assert!(next_one_or_two_or_three_tag(sentence.clone(), 0, Wordclass::JJ));
@@ -552,14 +552,14 @@ fn test_next_one_or_two_or_three_tag_found() {
 #[test]
 fn test_next_one_or_two_or_three_tag_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("lazy", Wordclass::JJ),
-        ("dog", Wordclass::JJ),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
-    assert!(!next_one_or_two_or_three_tag(sentence.clone(), 2, Wordclass::NN));
-    assert!(!next_one_or_two_or_three_tag(sentence.clone(), 3, Wordclass::NN));
+    assert!(!next_one_or_two_or_three_tag(sentence.clone(), 2, Wordclass::DT));
+    assert!(!next_one_or_two_or_three_tag(sentence.clone(), 3, Wordclass::DT));
 }
 
 
@@ -567,9 +567,9 @@ fn test_next_one_or_two_or_three_tag_not_found() {
 #[test]
 fn test_next_one_or_two_or_three_tag_out_of_bounds() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
     ];
     assert!(!next_one_or_two_or_three_tag(sentence.clone(), 2, Wordclass::NN));
     assert!(!next_one_or_two_or_three_tag(sentence.clone(), 1, Wordclass::NN));
@@ -580,11 +580,11 @@ fn test_next_one_or_two_or_three_tag_out_of_bounds() {
 #[test]
 fn test_word_and_tag_2_after_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
-        ("jumps", Wordclass::VB),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
+        (String::from("jumps"), Wordclass::VB),
     ];
     assert!(word_and_tag_2_after(sentence.clone(), 0, "The", Wordclass::JJ));
     assert!(word_and_tag_2_after(sentence.clone(), 1, "quick", Wordclass::NN));
@@ -595,11 +595,11 @@ fn test_word_and_tag_2_after_found() {
 #[test]
 fn test_word_and_tag_2_after_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
-        ("jumps", Wordclass::VB),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
+        (String::from("jumps"), Wordclass::VB),
     ];
     assert!(!word_and_tag_2_after(sentence.clone(), 0, "The", Wordclass::NN));
     assert!(!word_and_tag_2_after(sentence.clone(), 1, "quick", Wordclass::VB));
@@ -610,9 +610,9 @@ fn test_word_and_tag_2_after_not_found() {
 #[test]
 fn test_word_and_tag_2_after_out_of_bounds() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
     ];
     assert!(!word_and_tag_2_after(sentence.clone(), 2, "brown", Wordclass::NN));
     assert!(!word_and_tag_2_after(sentence.clone(), 1, "quick", Wordclass::NN));
@@ -623,11 +623,11 @@ fn test_word_and_tag_2_after_out_of_bounds() {
 #[test]
 fn test_word_and_2_after_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
-        ("jumps", Wordclass::VB),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
+        (String::from("jumps"), Wordclass::VB),
     ];
     assert!(word_and_2_after(sentence.clone(), 0, "The", "brown"));
     assert!(word_and_2_after(sentence.clone(), 1, "quick", "fox"));
@@ -638,11 +638,11 @@ fn test_word_and_2_after_found() {
 #[test]
 fn test_word_and_2_after_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
-        ("jumps", Wordclass::VB),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
+        (String::from("jumps"), Wordclass::VB),
     ];
     assert!(!word_and_2_after(sentence.clone(), 0, "The", "fox"));
     assert!(!word_and_2_after(sentence.clone(), 1, "quick", "jumps"));
@@ -652,9 +652,9 @@ fn test_word_and_2_after_not_found() {
 #[test]
 fn test_word_and_2_after_out_of_bounds() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
     ];
     assert!(!word_and_2_after(sentence.clone(), 1, "quick", "brown"));
     assert!(!word_and_2_after(sentence.clone(), 0, "The", "quick"));
@@ -664,10 +664,10 @@ fn test_word_and_2_after_out_of_bounds() {
 #[test]
 fn test_previous_one_or_two_word_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(previous_one_or_two_word(sentence.clone(), 1, "The"));
     assert!(previous_one_or_two_word(sentence.clone(), 3, "brown"));
@@ -677,10 +677,10 @@ fn test_previous_one_or_two_word_found() {
 #[test]
 fn test_previous_one_or_two_word_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!previous_one_or_two_word(sentence.clone(), 3, "The"));
     assert!(!previous_one_or_two_word(sentence.clone(), 2, "fox"));
@@ -690,8 +690,9 @@ fn test_previous_one_or_two_word_not_found() {
 #[test]
 fn test_previous_one_or_two_word_out_of_bounds() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
     ];
     assert!(!previous_one_or_two_word(sentence.clone(), 0, "quick"));
 }
@@ -699,11 +700,11 @@ fn test_previous_one_or_two_word_out_of_bounds() {
 #[test]
 fn test_prev_two_tag_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("lazy", Wordclass::JJ),
-        ("dog", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(prev_two_tag(sentence.clone(), 2, Wordclass::DT));
     assert!(prev_two_tag(sentence.clone(), 3, Wordclass::JJ));
@@ -713,11 +714,11 @@ fn test_prev_two_tag_found() {
 #[test]
 fn test_prev_two_tag_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("lazy", Wordclass::JJ),
-        ("dog", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!prev_two_tag(sentence.clone(), 3, Wordclass::NN));
     assert!(!prev_two_tag(sentence.clone(), 2, Wordclass::NN));
@@ -727,9 +728,9 @@ fn test_prev_two_tag_not_found() {
 #[test]
 fn test_prev_two_tag_out_of_bounds() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
     ];
     assert!(!prev_two_tag(sentence.clone(), 0, Wordclass::NN));
     assert!(!prev_two_tag(sentence.clone(), 1, Wordclass::NN));

--- a/src/rs_contextual_rulespec.rs
+++ b/src/rs_contextual_rulespec.rs
@@ -445,7 +445,7 @@ fn test_contextual_rule() {
         println!("{} {}", w, c);
     }
 
-    contextual_rule_apply(sentence.as_mut(), 2, rule);
+    contextual_rule_apply(sentence.as_mut(), 2, rule, );
 
     for (w, c) in sentence {
         println!("{} {}", w, c);

--- a/src/rs_contractions.rs
+++ b/src/rs_contractions.rs
@@ -27,7 +27,7 @@ fn expand_contraction(input: String, contractions_map: &HashMap<String, Vec<Stri
 
 
 /// Function to find contractions for a given `input`
-fn find_contractions(input: String) -> Result<Vec<String>, String> {
+pub fn find_contractions(input: String) -> Result<Vec<String>, String> {
     let contractions_map = load_contractions().map_err(|e| format!("Error loading contractions: {}", e))?;
 
     // Map the `input` to its corresponding contraction

--- a/src/rs_lexical_rulespec.rs
+++ b/src/rs_lexical_rulespec.rs
@@ -5,68 +5,68 @@ use crate::rs_lex_rulespec_id::{LexicalRuleID, LexicalRulespec};
 use itertools::Itertools;
 
 /// Function to check if the word at `current_index` has suffix `suffix` and is not yet tagged.
-pub fn has_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suffix: &str) -> bool {
+pub fn has_suffix(sentence: &Vec<(String, Wordclass)>, current_index: i32, suffix: &str) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(word, Wordclass::ANY)) => word.ends_with(suffix),
+        Some((word, Wordclass::ANY)) => word.ends_with(suffix),
         _ => false,
     }
 }
 
 
 /// Function to check if the word at `current_index` has suffix `suffix` and is tagged as `target_tag`.
-pub fn f_has_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suffix: &str, source_tag: Wordclass) -> bool {
-    match sentence.get(current_index as usize) {
+pub fn f_has_suffix(sentence: &Vec<(String, Wordclass)>, current_index: i32, suffix: &str, source_tag: Wordclass) -> bool {
+    match sentence.clone().get(current_index as usize) {
         Some(&(_, Wordclass::ANY)) => false,
-        Some(&(word, ref tag)) => word.ends_with(suffix) && tag.to_owned() == source_tag,
+        Some((word, ref tag)) => word.ends_with(suffix) && tag.to_owned() == source_tag,
         _ => false,
     }
 }
 
 
 /// Function to check if the word at `current_index` has suffix `prefix` and is not yet tagged.
-pub fn has_prefix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, prefix: &str) -> bool {
+pub fn has_prefix(sentence: &Vec<(String, Wordclass)>, current_index: i32, prefix: &str) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(word, Wordclass::ANY)) => word.starts_with(prefix),
+        Some((word, Wordclass::ANY)) => word.starts_with(prefix),
         _ => false,
     }
 }
 
 
 /// Function to check if the word at `current_index` has suffix `prefix` and is tagged as `target_tag`.
-pub fn f_has_prefix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, prefix: &str, source_tag: Wordclass) -> bool {
+pub fn f_has_prefix(sentence: &Vec<(String, Wordclass)>, current_index: i32, prefix: &str, source_tag: Wordclass) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(_, Wordclass::ANY)) => false,
-        Some(&(word, ref tag)) => word.starts_with(prefix) && tag.to_owned() == source_tag,
+        Some((_, Wordclass::ANY)) => false,
+        Some((word, ref tag)) => word.starts_with(prefix) && tag.to_owned() == source_tag,
         _ => false,
     }
 }
 
 
 /// Function to check if the word at `current_index` contains char `c` and is not yet tagged.
-pub fn has_char(sentence: &Vec<(&str, Wordclass)>, current_index: i32, c: char) -> bool {
+pub fn has_char(sentence: &Vec<(String, Wordclass)>, current_index: i32, c: char) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(word, Wordclass::ANY)) => word.contains(c),
+        Some((word, Wordclass::ANY)) => word.contains(c),
         _ => false,
     }
 }
 
 
 /// Function to check if the word at `current_index` contains char `c` and is tagged.
-pub fn f_has_char(sentence: &Vec<(&str, Wordclass)>, current_index: i32, c: char, source_tag: Wordclass) -> bool {
+pub fn f_has_char(sentence: &Vec<(String, Wordclass)>, current_index: i32, c: char, source_tag: Wordclass) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(_, Wordclass::ANY)) => false,
-        Some(&(word, ref tag)) => word.contains(c) && tag.to_owned() == source_tag,
+        Some((_, Wordclass::ANY)) => false,
+        Some((word, ref tag)) => word.contains(c) && tag.to_owned() == source_tag,
         _ => false,
     }
 }
 
 
 /// Function to check if the word at `current_index` is still a word if `suffix` is added, and is not yet tagged.
-pub fn add_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suffix: &str, wc_mapping: &WordclassMap) -> bool {
+pub fn add_suffix(sentence: &Vec<(String, Wordclass)>, current_index: i32, suffix: &str, wc_mapping: &WordclassMap) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(word, Wordclass::ANY)) => {
+        Some((word, Wordclass::ANY)) => {
             let modified_word = word.to_string() + suffix;
-            is_word_in_lexicon(modified_word.as_str(), wc_mapping)
+            is_word_in_lexicon(modified_word, wc_mapping)
         },
         _ => false,
     }
@@ -74,12 +74,12 @@ pub fn add_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suffix:
 
 
 /// Function to check if the word at `current_index` is still a word if `suffix` is added, and is tagged.
-pub fn f_add_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suffix: &str, source_tag: Wordclass, wc_mapping: &WordclassMap) -> bool {
+pub fn f_add_suffix(sentence: &Vec<(String, Wordclass)>, current_index: i32, suffix: &str, source_tag: Wordclass, wc_mapping: &WordclassMap) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(_, Wordclass::ANY)) => false,
-        Some(&(word, ref tag)) => {
+        Some((_, Wordclass::ANY)) => false,
+        Some((word, ref tag)) => {
             let modified_word = word.to_string() + suffix;
-            is_word_in_lexicon(modified_word.as_str(), wc_mapping) && tag.to_owned() == source_tag
+            is_word_in_lexicon(modified_word, wc_mapping) && tag.to_owned() == source_tag
         },
         _ => false,
     }
@@ -87,11 +87,11 @@ pub fn f_add_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suffi
 
 
 /// Function to check if the word at `current_index` is still a word if `suffix` is deleted, and is not yet tagged.
-pub fn delete_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suffix: &str, wc_mapping: &WordclassMap) -> bool {
+pub fn delete_suffix(sentence: &Vec<(String, Wordclass)>, current_index: i32, suffix: &str, wc_mapping: &WordclassMap) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(word, Wordclass::ANY)) => {
+        Some((word, Wordclass::ANY)) => {
             match word.strip_suffix(suffix) {
-                Some(modified_word) => is_word_in_lexicon(modified_word, wc_mapping),
+                Some(modified_word) => is_word_in_lexicon(String::from(modified_word), wc_mapping),
                 _ => false
             }
         },
@@ -101,12 +101,12 @@ pub fn delete_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suff
 
 
 /// Function to check if the word at `current_index` is still a word if `suffix` is deleted, and is tagged.
-pub fn f_delete_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, suffix: &str, source_tag: Wordclass, wc_mapping: &WordclassMap) -> bool {
+pub fn f_delete_suffix(sentence: &Vec<(String, Wordclass)>, current_index: i32, suffix: &str, source_tag: Wordclass, wc_mapping: &WordclassMap) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(_, Wordclass::ANY)) => false,
-        Some(&(word, ref tag)) => {
+        Some((_, Wordclass::ANY)) => false,
+        Some((word, ref tag)) => {
             match word.strip_suffix(suffix) {
-                Some(modified_word) => is_word_in_lexicon(modified_word, wc_mapping) && tag.to_owned() == source_tag,
+                Some(modified_word) => is_word_in_lexicon(String::from(modified_word), wc_mapping) && tag.to_owned() == source_tag,
                 _ => false
             }
         },
@@ -116,11 +116,11 @@ pub fn f_delete_suffix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, su
 
 
 /// Function to check if the word at `current_index` is still a word if `prefix` is deleted, and is not yet tagged.
-pub fn delete_prefix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, prefix: &str, wc_mapping: &WordclassMap) -> bool {
+pub fn delete_prefix(sentence: &Vec<(String, Wordclass)>, current_index: i32, prefix: &str, wc_mapping: &WordclassMap) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(word, Wordclass::ANY)) => {
+        Some((word, Wordclass::ANY)) => {
             match word.strip_prefix(prefix) {
-                Some(modified_word) => is_word_in_lexicon(modified_word, wc_mapping),
+                Some(modified_word) => is_word_in_lexicon(String::from(modified_word), wc_mapping),
                 _ => false
             }
         },
@@ -130,12 +130,12 @@ pub fn delete_prefix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, pref
 
 
 /// Function to check if the word at `current_index` is still a word if `prefix` is deleted, and is tagged.
-pub fn f_delete_prefix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, prefix: &str, source_tag: Wordclass, wc_mapping: &WordclassMap) -> bool {
+pub fn f_delete_prefix(sentence: &Vec<(String, Wordclass)>, current_index: i32, prefix: &str, source_tag: Wordclass, wc_mapping: &WordclassMap) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(_, Wordclass::ANY)) => false,
-        Some(&(word, ref tag)) => {
+        Some((_, Wordclass::ANY)) => false,
+        Some((word, ref tag)) => {
             match word.strip_prefix(prefix) {
-                Some(modified_word) => is_word_in_lexicon(modified_word, wc_mapping) && tag.to_owned() == source_tag,
+                Some(modified_word) => is_word_in_lexicon(String::from(modified_word), wc_mapping) && tag.to_owned() == source_tag,
                 _ => false
             }
         },
@@ -145,11 +145,11 @@ pub fn f_delete_prefix(sentence: &Vec<(&str, Wordclass)>, current_index: i32, pr
 
 
 /// Function to check if the word to the left of the word at `current_index` is `word` and is not yet tagged.
-pub fn appears_to_left(sentence: &Vec<(&str, Wordclass)>, current_index: i32, expected_word: &str) -> bool {
+pub fn appears_to_left(sentence: &Vec<(String, Wordclass)>, current_index: i32, expected_word: &str) -> bool {
     match sentence.get(current_index as usize) {
-        Some(&(_, Wordclass::ANY)) => {
+        Some((_, Wordclass::ANY)) => {
             match sentence.get((current_index - 1) as usize) {
-                Some(&(word, _)) => word == expected_word,
+                Some((word, _)) => word == expected_word,
                 _ => false,
             }
         }
@@ -160,13 +160,13 @@ pub fn appears_to_left(sentence: &Vec<(&str, Wordclass)>, current_index: i32, ex
 
 
 /// Function to check if the word to the left of the word at `current_index` is `word` and is tagged.
-pub fn f_appears_to_left(sentence: &Vec<(&str, Wordclass)>, current_index: i32, expected_word: &str, source_tag: Wordclass) -> bool {
+pub fn f_appears_to_left(sentence: &Vec<(String, Wordclass)>, current_index: i32, expected_word: &str, source_tag: Wordclass) -> bool {
     match sentence.get(current_index as usize) {
         Some(&(_, Wordclass::ANY)) => false,
         Some(&(_, ref tag)) => {
             match sentence.get((current_index - 1) as usize) {
 
-                Some(&(word, _)) => word == expected_word && tag.to_owned() == source_tag,
+                Some((word, _)) => word == expected_word && tag.to_owned() == source_tag,
                 _ => false,
             }
         }
@@ -177,11 +177,11 @@ pub fn f_appears_to_left(sentence: &Vec<(&str, Wordclass)>, current_index: i32, 
 
 
 /// Function to check if the word to the right of the word at `current_index` is `word` and is not yet tagged.
-pub fn appears_to_right(sentence: &Vec<(&str, Wordclass)>, current_index: i32, expected_word: &str) -> bool {
+pub fn appears_to_right(sentence: &Vec<(String, Wordclass)>, current_index: i32, expected_word: &str) -> bool {
     match sentence.get(current_index as usize) {
         Some(&(_, Wordclass::ANY)) => {
             match sentence.get((current_index + 1) as usize) {
-                Some(&(word, _)) => word == expected_word,
+                Some((word, _)) => word == expected_word,
                 _ => false,
             }
         }
@@ -192,13 +192,13 @@ pub fn appears_to_right(sentence: &Vec<(&str, Wordclass)>, current_index: i32, e
 
 
 /// Function to check if the word to the right of the word at `current_index` is `word` and is tagged.
-pub fn f_appears_to_right(sentence: &Vec<(&str, Wordclass)>, current_index: i32, expected_word: &str, source_tag: Wordclass) -> bool {
+pub fn f_appears_to_right(sentence: &Vec<(String, Wordclass)>, current_index: i32, expected_word: &str, source_tag: Wordclass) -> bool {
     match sentence.get(current_index as usize) {
         Some(&(_, Wordclass::ANY)) => false,
         Some(&(_, ref tag)) => {
             match sentence.get((current_index + 1) as usize) {
 
-                Some(&(word, _)) => word == expected_word && tag.to_owned() == source_tag,
+                Some((word, _)) => word == expected_word && tag.to_owned() == source_tag,
                 _ => false,
             }
         }
@@ -209,8 +209,8 @@ pub fn f_appears_to_right(sentence: &Vec<(&str, Wordclass)>, current_index: i32,
 
 
 /// Function to check if `word` appears in the Wordclass mappings retrieved from the lexicon.
-pub fn is_word_in_lexicon(word: &str, wc_mapping: &WordclassMap) -> bool {
-    match wc_mapping.get(word) {
+pub fn is_word_in_lexicon(word: String, wc_mapping: &WordclassMap) -> bool {
+    match wc_mapping.get(&word) {
         Some(_) => true,
         _ => false
     }
@@ -218,7 +218,7 @@ pub fn is_word_in_lexicon(word: &str, wc_mapping: &WordclassMap) -> bool {
 
 
 /// Checks a given lexical rule.
-pub fn lexical_rule_holds(sentence: &mut Vec<(&str, Wordclass)>, current_index: i32, rule: &LexicalRulespec, wc_mapping: &WordclassMap) -> Option<bool> {
+pub fn lexical_rule_holds(sentence: &mut Vec<(String, Wordclass)>, current_index: i32, rule: &LexicalRulespec, wc_mapping: &WordclassMap) -> Option<bool> {
 
     match rule.ruleset_id {
         LexicalRuleID::HASSUF => {
@@ -407,7 +407,7 @@ pub fn lexical_rule_holds(sentence: &mut Vec<(&str, Wordclass)>, current_index: 
 
 
 /// Applies a given lexical rule.
-pub fn lexical_rule_apply(sentence: &mut Vec<(&str, Wordclass)>, current_index: i32, rule: &LexicalRulespec) -> Option<bool> {
+pub fn lexical_rule_apply(sentence: &mut Vec<(String, Wordclass)>, current_index: i32, rule: &LexicalRulespec) -> Option<bool> {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
 
     let uindex: usize = current_index as usize;
@@ -416,7 +416,7 @@ pub fn lexical_rule_apply(sentence: &mut Vec<(&str, Wordclass)>, current_index: 
     match lexical_rule_holds(sentence, current_index, rule, &wc_mapping) {
         Some(true) => {
             let new_tag = rule.clone().target_tag;
-            sentence[uindex] = (sentence[uindex].0, new_tag);
+            sentence[uindex].1 = new_tag;
             Option::from(true)
         }
         _ => Option::from(false),
@@ -429,10 +429,10 @@ fn test_lexical_rule_apply() {
 
 
     let mut sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
 
     println!("sentence before: {:?}", sentence);
@@ -454,11 +454,11 @@ fn test_lexical_rule_apply() {
 #[test]
 fn test_appears_to_left_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::ANY),
+        (String::from("quick"), Wordclass::ANY),
+        (String::from("brown"), Wordclass::ANY),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(appears_to_left(&sentence, 1, "The"));
     assert!(appears_to_left(&sentence, 2, "quick"));
@@ -469,11 +469,11 @@ fn test_appears_to_left_found() {
 #[test]
 fn test_appears_to_left_not_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!appears_to_left(&sentence, 1, "The"));
     assert!(!appears_to_left(&sentence, 2, "none"));
@@ -484,10 +484,10 @@ fn test_appears_to_left_not_found() {
 #[test]
 fn test_f_appears_to_left_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(f_appears_to_left(&sentence, 1, "The", Wordclass::JJ));
     assert!(f_appears_to_left(&sentence, 2, "quick", Wordclass::JJ));
@@ -498,10 +498,10 @@ fn test_f_appears_to_left_found() {
 #[test]
 fn test_f_appears_to_left_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quickest", Wordclass::ANY),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quickest"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!f_appears_to_left(&sentence, 1, "The", Wordclass::ANY));
     assert!(!f_appears_to_left(&sentence, 2, "none", Wordclass::JJ));
@@ -512,11 +512,11 @@ fn test_f_appears_to_left_not_found() {
 #[test]
 fn test_appears_to_right_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::ANY),
+        (String::from("quick"), Wordclass::ANY),
+        (String::from("brown"), Wordclass::ANY),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(appears_to_right(&sentence, 1, "brown"));
     assert!(appears_to_right(&sentence, 2, "lazy"));
@@ -527,11 +527,11 @@ fn test_appears_to_right_found() {
 #[test]
 fn test_appears_to_right_not_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!appears_to_right(&sentence, 1, "brown"));
     assert!(!appears_to_right(&sentence, 2, "none"));
@@ -542,10 +542,10 @@ fn test_appears_to_right_not_found() {
 #[test]
 fn test_f_appears_to_right_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(f_appears_to_right(&sentence, 1, "brown", Wordclass::JJ));
     assert!(f_appears_to_right(&sentence, 2, "fox", Wordclass::JJ));
@@ -556,10 +556,10 @@ fn test_f_appears_to_right_found() {
 #[test]
 fn test_f_appears_to_right_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!f_appears_to_right(&sentence, 1, "quick", Wordclass::ANY));
     assert!(!f_appears_to_right(&sentence, 2, "none", Wordclass::JJ));
@@ -571,11 +571,11 @@ fn test_f_appears_to_right_not_found() {
 fn test_delete_suffix_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quickest", Wordclass::ANY),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::ANY),
+        (String::from("quickest"), Wordclass::ANY),
+        (String::from("brown"), Wordclass::ANY),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(delete_suffix(&sentence, 1, "est", &wc_mapping));
     assert!(delete_suffix(&sentence, 2, "n", &wc_mapping));
@@ -587,11 +587,11 @@ fn test_delete_suffix_found() {
 fn test_delete_suffix_not_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quickest", Wordclass::JJ),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quickest"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!delete_suffix(&sentence, 1, "est", &wc_mapping));
     assert!(!delete_suffix(&sentence, 2, "own", &wc_mapping));
@@ -603,10 +603,10 @@ fn test_delete_suffix_not_found() {
 fn test_delete_f_suffix_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quickest", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quickest"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(f_delete_suffix(&sentence, 1, "est", Wordclass::JJ, &wc_mapping));
     assert!(f_delete_suffix(&sentence, 2, "n", Wordclass::JJ, &wc_mapping));
@@ -618,10 +618,10 @@ fn test_delete_f_suffix_found() {
 fn test_delete_f_suffix_not_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quickest", Wordclass::ANY),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!f_delete_suffix(&sentence, 1, "est", Wordclass::ANY, &wc_mapping));
     assert!(!f_delete_suffix(&sentence, 2, "own", Wordclass::JJ, &wc_mapping));
@@ -633,11 +633,11 @@ fn test_delete_f_suffix_not_found() {
 fn test_delete_prefix_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("unquick", Wordclass::ANY),
-        ("unbrown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::ANY),
+        (String::from("unquick"), Wordclass::ANY),
+        (String::from("unbrown"), Wordclass::ANY),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(delete_prefix(&sentence, 1, "un", &wc_mapping));
     assert!(delete_prefix(&sentence, 2, "un", &wc_mapping));
@@ -649,11 +649,11 @@ fn test_delete_prefix_found() {
 fn test_delete_prefix_not_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("unquick", Wordclass::JJ),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("unquick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!delete_prefix(&sentence, 1, "un", &wc_mapping));
     assert!(!delete_prefix(&sentence, 2, "aaa", &wc_mapping));
@@ -666,10 +666,10 @@ fn test_delete_prefix_not_found() {
 fn test_delete_f_prefix_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("unquick", Wordclass::JJ),
-        ("unbrown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("unquick"), Wordclass::JJ),
+        (String::from("unbrown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(f_delete_prefix(&sentence, 1, "un", Wordclass::JJ, &wc_mapping));
     assert!(f_delete_prefix(&sentence, 2, "un", Wordclass::JJ, &wc_mapping));
@@ -681,10 +681,10 @@ fn test_delete_f_prefix_found() {
 fn test_delete_f_prefix_not_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("unquick", Wordclass::ANY),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("unquick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!f_delete_prefix(&sentence, 1, "un", Wordclass::ANY, &wc_mapping));
     assert!(!f_delete_prefix(&sentence, 2, "zzz", Wordclass::JJ, &wc_mapping));
@@ -697,11 +697,11 @@ fn test_delete_f_prefix_not_found() {
 fn test_add_suffix_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::ANY),
+        (String::from("quick"), Wordclass::ANY),
+        (String::from("brown"), Wordclass::ANY),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(add_suffix(&sentence, 1, "est", &wc_mapping));
     assert!(add_suffix(&sentence, 2, "ed", &wc_mapping));
@@ -713,11 +713,11 @@ fn test_add_suffix_found() {
 fn test_add_suffix_not_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!add_suffix(&sentence, 1, "est", &wc_mapping));
     assert!(!add_suffix(&sentence, 2, "zzz", &wc_mapping));
@@ -729,10 +729,10 @@ fn test_add_suffix_not_found() {
 fn test_add_f_suffix_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(f_add_suffix(&sentence, 1, "est", Wordclass::JJ, &wc_mapping));
     assert!(f_add_suffix(&sentence, 2, "ed", Wordclass::JJ, &wc_mapping));
@@ -744,10 +744,10 @@ fn test_add_f_suffix_found() {
 fn test_add_f_suffix_not_found() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!f_add_suffix(&sentence, 1, "est", Wordclass::ANY, &wc_mapping));
     assert!(!f_add_suffix(&sentence, 2, "zzz", Wordclass::JJ, &wc_mapping));
@@ -758,27 +758,27 @@ fn test_add_f_suffix_not_found() {
 #[test]
 fn test_word_in_lexicon() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
-    assert!(is_word_in_lexicon("apple", &wc_mapping));
-    assert!(is_word_in_lexicon("banana", &wc_mapping));
+    assert!(is_word_in_lexicon(String::from("apple"), &wc_mapping));
+    assert!(is_word_in_lexicon(String::from("banana"), &wc_mapping));
 }
 
 
 #[test]
 fn test_word_not_in_lexicon() {
     let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
-    assert!(!is_word_in_lexicon("abcde", &wc_mapping));
-    assert!(!is_word_in_lexicon("", &wc_mapping));
+    assert!(!is_word_in_lexicon(String::from("abcde"), &wc_mapping));
+    assert!(!is_word_in_lexicon(String::from(""), &wc_mapping));
 }
 
 
 #[test]
 fn test_has_suffix_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::ANY),
+        (String::from("brown"), Wordclass::ANY),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(has_suffix(&sentence, 1, "ick"));
     assert!(has_suffix(&sentence, 2, "rown"));
@@ -789,11 +789,11 @@ fn test_has_suffix_found() {
 #[test]
 fn test_has_suffix_not_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!has_suffix(&sentence, 1, "ick"));
     assert!(!has_suffix(&sentence, 2, "abcd"));
@@ -804,10 +804,10 @@ fn test_has_suffix_not_found() {
 #[test]
 fn test_has_f_suffix_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(f_has_suffix(&sentence, 1, "ick", Wordclass::JJ));
     assert!(f_has_suffix(&sentence, 2, "rown", Wordclass::JJ));
@@ -818,10 +818,10 @@ fn test_has_f_suffix_found() {
 #[test]
 fn test_has_f_suffix_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!f_has_suffix(&sentence, 1, "ick", Wordclass::ANY));
     assert!(!f_has_suffix(&sentence, 2, "abcd", Wordclass::JJ));
@@ -832,11 +832,11 @@ fn test_has_f_suffix_not_found() {
 #[test]
 fn test_has_prefix_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::ANY),
+        (String::from("brown"), Wordclass::ANY),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(has_prefix(&sentence, 1, "qui"));
     assert!(has_prefix(&sentence, 2, "bro"));
@@ -847,11 +847,11 @@ fn test_has_prefix_found() {
 #[test]
 fn test_has_prefix_not_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::ANY),
-        ("lazy", Wordclass::ANY),
-        ("dog", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(!has_prefix(&sentence, 1, "qui"));
     assert!(!has_prefix(&sentence, 2, "abcd"));
@@ -862,10 +862,10 @@ fn test_has_prefix_not_found() {
 #[test]
 fn test_has_f_prefix_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(f_has_prefix(&sentence, 1, "qui", Wordclass::JJ));
     assert!(f_has_prefix(&sentence, 2, "bro", Wordclass::JJ));
@@ -876,10 +876,10 @@ fn test_has_f_prefix_found() {
 #[test]
 fn test_has_f_prefix_not_found() {
     let sentence = vec![
-        ("The", Wordclass::DT),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::NN),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!f_has_prefix(&sentence, 1, "qui", Wordclass::ANY));
     assert!(!f_has_prefix(&sentence, 2, "abcd", Wordclass::JJ));
@@ -890,10 +890,11 @@ fn test_has_f_prefix_not_found() {
 #[test]
 fn test_has_char_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::ANY),
-        ("fox", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::ANY),
+        (String::from("brown"), Wordclass::ANY),
+        (String::from("lazy"), Wordclass::JJ),
+        (String::from("dog"), Wordclass::NN),
     ];
     assert!(has_char(&sentence, 1, 'q'));
     assert!(has_char(&sentence, 2, 'n'));
@@ -904,10 +905,10 @@ fn test_has_char_found() {
 #[test]
 fn test_has_char_not_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::ANY),
-        ("fox", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!has_char(&sentence, 1, 'q'));
     assert!(!has_char(&sentence, 2, 'k'));
@@ -918,10 +919,10 @@ fn test_has_char_not_found() {
 #[test]
 fn test_f_has_char_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::JJ),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(f_has_char(&sentence, 1, 'q', Wordclass::JJ));
     assert!(f_has_char(&sentence, 2, 'n', Wordclass::JJ));
@@ -932,10 +933,10 @@ fn test_f_has_char_found() {
 #[test]
 fn test_f_has_char_not_found() {
     let sentence = vec![
-        ("The", Wordclass::ANY),
-        ("quick", Wordclass::ANY),
-        ("brown", Wordclass::JJ),
-        ("fox", Wordclass::ANY),
+        (String::from("The"), Wordclass::DT),
+        (String::from("quick"), Wordclass::JJ),
+        (String::from("brown"), Wordclass::JJ),
+        (String::from("fox"), Wordclass::NN),
     ];
     assert!(!f_has_char(&sentence, 1, 'q', Wordclass::ANY));
     assert!(!f_has_char(&sentence, 2, 'k', Wordclass::JJ));

--- a/src/rs_lexical_rulespec.rs
+++ b/src/rs_lexical_rulespec.rs
@@ -1,6 +1,5 @@
 use crate::rs_wordclass::{map_pos_tag, Wordclass};
-use crate::WordclassMap;
-use crate::initialize_tagger;
+use crate::{initialize_tagger, WordclassMap};
 use crate::rs_lex_rulespec_id::{LexicalRuleID, LexicalRulespec};
 use itertools::Itertools;
 

--- a/src/rs_lexical_rulespec.rs
+++ b/src/rs_lexical_rulespec.rs
@@ -407,8 +407,7 @@ pub fn lexical_rule_holds(sentence: &mut Vec<(String, Wordclass)>, current_index
 
 
 /// Applies a given lexical rule.
-pub fn lexical_rule_apply(sentence: &mut Vec<(String, Wordclass)>, current_index: i32, rule: &LexicalRulespec) -> Option<bool> {
-    let wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
+pub fn lexical_rule_apply(sentence: &mut Vec<(String, Wordclass)>, current_index: i32, rule: &LexicalRulespec, wc_mapping: &WordclassMap) -> Option<bool> {
 
     let uindex: usize = current_index as usize;
 
@@ -426,6 +425,7 @@ pub fn lexical_rule_apply(sentence: &mut Vec<(String, Wordclass)>, current_index
 
 #[test]
 fn test_lexical_rule_apply() {
+    let mut wc_mapping: WordclassMap = initialize_tagger("data/lexicon.txt").unwrap();
 
 
     let mut sentence = vec![
@@ -443,7 +443,7 @@ fn test_lexical_rule_apply() {
         parameters: vec![String::from("JJ"), "ick".parse().unwrap()],
     };
 
-    assert!(lexical_rule_apply(&mut sentence, 1, &rule_fhassuf).unwrap());
+    assert!(lexical_rule_apply(&mut sentence, 1, &rule_fhassuf, &wc_mapping).unwrap());
 
     println!("sentence after: {:?}", sentence);
 

--- a/src/rs_wordclass.rs
+++ b/src/rs_wordclass.rs
@@ -130,6 +130,7 @@ pub fn map_pos_tag(tag: &str) -> Result<Wordclass, Error> {
         "WRB" => Ok(Wordclass::WRB),
         ":" => Ok(Wordclass::ANY),
         "''" => Ok(Wordclass::ANY),
+        tag if tag.contains("|") => Ok(Wordclass::ANY),
         _ => Err(Error::new(ErrorKind::InvalidData, format!("Invalid POS Tag Identifier: {}", tag))),
     }
 }


### PR DESCRIPTION
## Pull Request Description
<!-- Please provide a concise summary of the changes introduced in this pull request, along with references to any related issues. Also, list any dependencies that are necessary for these changes. -->
Implemented lexical rules for the Brill tagger, including FCFS heuristic and handling for unknown words. Refined logic to apply rules based on possible tags, updated Wordclass::ANY meaning, and integrated tokenizer. Refactored word type for consistency. Tests added for lexical rules; full Brill tagger testing pending benchmark implementation.

### Features
- Implemented lexical rules used in the Brill tagger (src/rs_lexical_rulespec.rs).
- Altered rule logic: do not apply a rule if its target tag is not in the word's list of possible tags.
- Added FCFS heuristic: apply transformations on the first tag of each word. Continue until either:
  - Each word is correctly tagged, or
  - The maximum number of iterations is reached.
- Altered the meaning of `Wordclass::ANY`: this means the word is not yet tagged.
- Added logic for unknown words: tag unknown words as `Wordclass::Any`, (this logic needs to be refined in a further issue to match Brill's technique).
- Integrated tokenizer from a separate issue.

### Tests
Tested each lexical rule with at least two tests. Yet to test brill tagger, must first implement a benchmarker.

### Refactors
Changed a word to be of type String instead of &str for consistency.

### This pull request introduces the following updates:
- [ ] Resolves one or more bugs (non-breaking modification that addresses an issue).
- [X] Introduces one or more new features (non-breaking addition of new functionality).
- [X] Adds documentation (such as Doxygen or other relevant documentation formats).
- [X] Refactors code (non-breaking change aimed at improving code structure or readability).
- [X] Adds one or more tests to the repository.
- [X] Includes additional modifications (please specify).

### Commitments to the repository:
- [X] I have conducted a thorough self-review of the code.
- [ ] I have implemented tests that validate the functionality of the fix or feature.
- [X] I have updated relevant documentation to reflect the changes made.
- [X] My changes do not introduce any new warnings or errors.
