### PR TITLE
69 handle quantifiers of quantifiers

### DIFF
--- a/src/ccg/node.rs
+++ b/src/ccg/node.rs
@@ -163,11 +163,7 @@ impl CCGNode {
 
     /// Checks if a node or its descendants contain a quantification node.
     pub fn contains_quantification_node(&self) -> bool {
-        if let Some(word) = &self.word {
-            if UNIVERSAL_QUANTIFIERS.contains(&word.text) || EXISTENTIAL_QUANTIFIERS.contains(&word.text) {
-                return true;
-            }
-        }
+        if self.is_quantification_node() {return true;}
 
         if let Some(children) = &self.children {
             for child in children {
@@ -177,6 +173,14 @@ impl CCGNode {
             }
         }
         false
+    }
+
+    pub fn is_quantification_node(&self) -> bool {
+        if let Some(word) = &self.word {
+            if UNIVERSAL_QUANTIFIERS.contains(&word.text) || EXISTENTIAL_QUANTIFIERS.contains(&word.text) {
+                return true;
+            }
+        } false
     }
 }
 

--- a/src/ccg/node.rs
+++ b/src/ccg/node.rs
@@ -156,7 +156,9 @@ impl CCGNode {
             if parent.node_type == CCGType::Sentence {
                 if let Some(children) = &parent.children {
                     if let Some(lhs) = children.first() {
-                        return Some(lhs);
+                        if !lhs.contains_quantification_node() {
+                            return Some(lhs);
+                        }
                     }
                 }
             }

--- a/src/ccg/node.rs
+++ b/src/ccg/node.rs
@@ -20,12 +20,6 @@ pub struct CCGNode {
     pub rule: CCGRule,
     pub children: Option<Vec<Box<CCGNode>>>, // Use Box to handle recursion
 
-    #[serde(skip)]
-    pub is_universal_quantification_node: bool,
-
-    #[serde(skip)]
-    pub is_existential_quantification_node: bool,
-
     // a unique identifier to differentiate nodes with the same text
     #[serde(skip)]
     pub id: Uuid
@@ -169,9 +163,12 @@ impl CCGNode {
 
     /// Checks if a node or its descendants contain a quantification node.
     pub fn contains_quantification_node(&self) -> bool {
-        if self.is_universal_quantification_node || self.is_existential_quantification_node {
-            return true;
+        if let Some(word) = &self.word {
+            if UNIVERSAL_QUANTIFIERS.contains(&word.text) || EXISTENTIAL_QUANTIFIERS.contains(&word.text) {
+                return true;
+            }
         }
+
         if let Some(children) = &self.children {
             for child in children {
                 if child.contains_quantification_node() {
@@ -180,29 +177,6 @@ impl CCGNode {
             }
         }
         false
-    }
-
-
-    // Recursive function to initialize flags
-    pub fn initialize_flags(&mut self) {
-        // Set the flags to false by default
-        self.is_existential_quantification_node = false;
-        self.is_universal_quantification_node = false;
-
-        if let Some(ccg_word) = self.clone().word {
-            let word_text = ccg_word.text.to_lowercase();
-            if UNIVERSAL_QUANTIFIERS.contains(&word_text) {
-                self.is_universal_quantification_node = true;
-            } else if EXISTENTIAL_QUANTIFIERS.contains(&word_text) {
-                self.is_existential_quantification_node = true;
-            }
-        }
-
-        if let Some(children) = &mut self.children {
-            for child in children.iter_mut() {
-                child.initialize_flags();
-            }
-        }
     }
 }
 

--- a/src/ccg/tag_insertion.rs
+++ b/src/ccg/tag_insertion.rs
@@ -35,8 +35,6 @@ fn _insert_tags<I>(old_node: &CCGNode, words_and_tags_iter: &mut I) -> CCGNode w
         rule: old_node.rule.clone(),
         word: new_word,
         children: new_children,
-        is_universal_quantification_node: old_node.is_universal_quantification_node,
-        is_existential_quantification_node: old_node.is_existential_quantification_node,
         id: Uuid::new_v4(), // Generate a unique ID
     }
 }

--- a/src/lambda/abstraction.rs
+++ b/src/lambda/abstraction.rs
@@ -15,22 +15,18 @@ pub struct Abstraction {
 impl Substitutable for Abstraction {
     fn substitute(&self, source: &LambdaEntity, target: &LambdaEntity) -> Box<LambdaEntity> {
 
-        println!("abstraction substituting {}, {} in {}", source, target, self);
         let bound_variable = &self.bound_var;
         let subexpr = &self.body;
 
-        // If we're substituting the bound variable ignore.
+        /// If we're substituting the bound variable ignore.
         // TODO: We should fix this at some point, using De Bruijin Indicies, renaming the BV.
-        /*if *&self.bound_var == Box::from(source.clone()) {
+        if *&self.bound_var == Box::from(source.clone()) {
             λAbs!(bound_variable.clone(), subexpr.clone())
 
         // Otherwise, substitute in the sub expression.
-        } else*/
-        {
+        } else {
             let subexpr_substituted: Box<LambdaEntity> = subexpr.substitute(source, target);
-            let expr = λAbs!(bound_variable.clone(), subexpr_substituted);
-            println!("expr: {}", expr);
-            expr
+            λAbs!(bound_variable.clone(), subexpr_substituted)
         }
     }
 }

--- a/src/lambda/abstraction.rs
+++ b/src/lambda/abstraction.rs
@@ -14,18 +14,23 @@ pub struct Abstraction {
 /// Implementation of λ-substitution for λ-Abstractions.
 impl Substitutable for Abstraction {
     fn substitute(&self, source: &LambdaEntity, target: &LambdaEntity) -> Box<LambdaEntity> {
+
+        println!("abstraction substituting {}, {} in {}", source, target, self);
         let bound_variable = &self.bound_var;
         let subexpr = &self.body;
 
         // If we're substituting the bound variable ignore.
         // TODO: We should fix this at some point, using De Bruijin Indicies, renaming the BV.
-        if *&self.bound_var == Box::from(source.clone()) {
+        /*if *&self.bound_var == Box::from(source.clone()) {
             λAbs!(bound_variable.clone(), subexpr.clone())
 
         // Otherwise, substitute in the sub expression.
-        } else {
+        } else*/
+        {
             let subexpr_substituted: Box<LambdaEntity> = subexpr.substitute(source, target);
-            λAbs!(bound_variable.clone(), subexpr_substituted)
+            let expr = λAbs!(bound_variable.clone(), subexpr_substituted);
+            println!("expr: {}", expr);
+            expr
         }
     }
 }

--- a/src/lambda/dependent_function.rs
+++ b/src/lambda/dependent_function.rs
@@ -35,6 +35,7 @@ impl Substitutable for DependentFunction {
             return Box::new(target.clone());
         }
 
+        // If the EXPR of a dependent function is an abstraction, perform substitution inside the EXPR.
         match *self.clone().expr {
             LambdaEntity:: Abs(abstraction) => {
                 λDepFun!(self.bound_var.substitute(&*abstraction.clone().bound_var, target), self.expr.substitute(&*abstraction.clone().bound_var, target))

--- a/src/lambda/dependent_function.rs
+++ b/src/lambda/dependent_function.rs
@@ -37,8 +37,6 @@ impl Substitutable for DependentFunction {
 
         match *self.clone().expr {
             LambdaEntity:: Abs(abstraction) => {
-                println!("substitute {:?} {}", source, target);
-
                 λDepFun!(self.bound_var.substitute(&*abstraction.clone().bound_var, target), self.expr.substitute(&*abstraction.clone().bound_var, target))
             }
             _ => {λDepFun!(self.clone().bound_var, self.clone().expr)}

--- a/src/lambda/dependent_function.rs
+++ b/src/lambda/dependent_function.rs
@@ -35,7 +35,14 @@ impl Substitutable for DependentFunction {
             return Box::new(target.clone());
         }
 
-        λDepFun!(self.bound_var.substitute(source, target), self.expr.substitute(source, target))
+        match *self.clone().expr {
+            LambdaEntity:: Abs(abstraction) => {
+                println!("substitute {:?} {}", source, target);
+
+                λDepFun!(self.bound_var.substitute(&*abstraction.clone().bound_var, target), self.expr.substitute(&*abstraction.clone().bound_var, target))
+            }
+            _ => {λDepFun!(self.clone().bound_var, self.clone().expr)}
+        }
     }
 }
 

--- a/src/lambda/dependent_sum.rs
+++ b/src/lambda/dependent_sum.rs
@@ -1,7 +1,7 @@
 use std::cmp::PartialEq;
 use crate::lambda::types::{Expandable, LambdaEntity, Substitutable};
 use crate::lambda::conjunction::Conjunction;
-use crate::{λConj, λPred, λDepSum};
+use crate::{λConj, λPred, λDepSum, λDepFun};
 use std::fmt;
 use std::fmt::Formatter;
 use crate::lambda::reducible::Reducible;
@@ -35,7 +35,12 @@ impl Substitutable for DependentSum {
             return Box::new(target.clone());
         }
 
-        λDepSum!(self.bound_var.substitute(source, target), self.expr.substitute(source, target))
+        match *self.clone().expr {
+            LambdaEntity:: Abs(abstraction) => {
+                λDepSum!(self.bound_var.substitute(&*abstraction.clone().bound_var, target), self.expr.substitute(&*abstraction.clone().bound_var, target))
+            }
+            _ => {λDepSum!(self.clone().bound_var, self.clone().expr)}
+        }
     }
 }
 

--- a/src/lambda/dependent_sum.rs
+++ b/src/lambda/dependent_sum.rs
@@ -35,6 +35,7 @@ impl Substitutable for DependentSum {
             return Box::new(target.clone());
         }
 
+        // If the EXPR of a dependent sum is an abstraction, perform substitution inside the EXPR.
         match *self.clone().expr {
             LambdaEntity:: Abs(abstraction) => {
                 λDepSum!(self.bound_var.substitute(&*abstraction.clone().bound_var, target), self.expr.substitute(&*abstraction.clone().bound_var, target))

--- a/src/lambda/macros.rs
+++ b/src/lambda/macros.rs
@@ -37,6 +37,7 @@ macro_rules! λConj {
     };
 }
 
+
 #[macro_export]
 macro_rules! λDepFun {
     ($bound_var:expr, $expr:expr) => {

--- a/src/lambda/reducible.rs
+++ b/src/lambda/reducible.rs
@@ -58,8 +58,14 @@ impl Reducible for LambdaEntity {
                         })
                     }
                     LambdaEntity::DepFun(function) => {
+                        // Perform substitution: replace the bound variable with the argument (rhs) in the body
+                        let substituted_body = function
+                            .substitute(&function.expr, &application.rhs);
 
-                        println!("REDUCING FUN: {}", function);
+                        // Continue reducing the substituted body
+                        substituted_body.beta_reduce()
+                    }
+                    LambdaEntity::DepSum(function) => {
                         // Perform substitution: replace the bound variable with the argument (rhs) in the body
                         let substituted_body = function
                             .substitute(&function.expr, &application.rhs);

--- a/src/lambda/reducible.rs
+++ b/src/lambda/reducible.rs
@@ -27,16 +27,13 @@ impl Reducible for LambdaEntity {
                     // If the reduced lhs is an Abstraction, perform substitution
                     LambdaEntity::Abs(abstraction) => {
 
-                        println!("substituting {}", application);
                         // Perform substitution: replace the bound variable with the argument (rhs) in the body
                         let substituted_body = abstraction
                             .body
                             .substitute(&abstraction.bound_var, &application.rhs);
 
                         // Continue reducing the substituted body
-                        let expr = substituted_body.beta_reduce();
-                        println!("expr: {}", expr);
-                        expr
+                        substituted_body.beta_reduce()
                     }
                     LambdaEntity::Conj(conjunction) => {
                         // NEW: Distribute 'rhs' over both sides of Conj(...).

--- a/src/lambda/reducible.rs
+++ b/src/lambda/reducible.rs
@@ -26,13 +26,17 @@ impl Reducible for LambdaEntity {
                 match reduced_lhs {
                     // If the reduced lhs is an Abstraction, perform substitution
                     LambdaEntity::Abs(abstraction) => {
+
+                        println!("substituting {}", application);
                         // Perform substitution: replace the bound variable with the argument (rhs) in the body
                         let substituted_body = abstraction
                             .body
                             .substitute(&abstraction.bound_var, &application.rhs);
 
                         // Continue reducing the substituted body
-                        substituted_body.beta_reduce()
+                        let expr = substituted_body.beta_reduce();
+                        println!("expr: {}", expr);
+                        expr
                     }
                     LambdaEntity::Conj(conjunction) => {
                         // NEW: Distribute 'rhs' over both sides of Conj(...).
@@ -58,20 +62,15 @@ impl Reducible for LambdaEntity {
                         })
                     }
                     LambdaEntity::DepFun(function) => {
-                        // Perform substitution: replace the bound variable with the argument (rhs) in the body
-                        let substituted_body = function
-                            .substitute(&function.expr, &application.rhs);
-
                         // Continue reducing the substituted body
-                        substituted_body.beta_reduce()
+                        let body = λApp!(function.expr, application.clone().rhs).beta_reduce();
+                        *λDepFun!(function.bound_var, Box::from(body))
+
                     }
                     LambdaEntity::DepSum(function) => {
-                        // Perform substitution: replace the bound variable with the argument (rhs) in the body
-                        let substituted_body = function
-                            .substitute(&function.expr, &application.rhs);
-
                         // Continue reducing the substituted body
-                        substituted_body.beta_reduce()
+                        let body = λApp!(function.expr, application.clone().rhs).beta_reduce();
+                        *λDepSum!(function.bound_var, Box::from(body))
                     }
                     other => {
                         // If not an Abs or Conj, reduce the rhs and rebuild App

--- a/src/lambda/reducible.rs
+++ b/src/lambda/reducible.rs
@@ -57,6 +57,16 @@ impl Reducible for LambdaEntity {
                             rhs: Box::new(rhs_applied),
                         })
                     }
+                    LambdaEntity::DepFun(function) => {
+
+                        println!("REDUCING FUN: {}", function);
+                        // Perform substitution: replace the bound variable with the argument (rhs) in the body
+                        let substituted_body = function
+                            .substitute(&function.expr, &application.rhs);
+
+                        // Continue reducing the substituted body
+                        substituted_body.beta_reduce()
+                    }
                     other => {
                         // If not an Abs or Conj, reduce the rhs and rebuild App
                         let reduced_rhs = application.rhs.beta_reduce();

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 
     // TODO: Contractions break the tagger (don't does not get a tag etc)
 
-    let sentence = "every man likes every cheese";
+    let sentence = "every man likes cheese and every woman likes gouda";
     //let sentence = "john likes every cheese and every man and some woman likes brie";
     // retrieve words and their corresponding pos tags
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ fn main() {
 
     // TODO: Contractions break the tagger (don't does not get a tag etc)
 
-    //let sentence = "every man likes every cheese";
-    let sentence = "john likes every cheese and every man and some woman likes brie";
+    let sentence = "every man likes every cheese";
+    //let sentence = "john likes every cheese and every man and some woman likes brie";
     // retrieve words and their corresponding pos tags
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 
     // TODO: Contractions break the tagger (don't does not get a tag etc)
 
-    let sentence = "every man likes cheese and every woman likes gouda";
+    let sentence = "every man likes every cheese and every woman likes some gouda";
     //let sentence = "john likes every cheese and every man and some woman likes brie";
     // retrieve words and their corresponding pos tags
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 
     // TODO: Contractions break the tagger (don't does not get a tag etc)
 
-    let sentence = "every man likes every cheese and every woman likes some gouda";
+    let sentence = "every man likes every cheese";
     //let sentence = "john likes every cheese and every man and some woman likes brie";
     // retrieve words and their corresponding pos tags
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ fn main() {
 
     // TODO: Contractions break the tagger (don't does not get a tag etc)
 
-    let sentence = "every man likes every cheese";
-    //let sentence = "john likes every cheese and every man and some woman likes brie";
+    //let sentence = "every man likes every cheese";
+    let sentence = "john likes every cheese and every man and some woman likes brie";
     // retrieve words and their corresponding pos tags
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,8 +21,8 @@ fn main() {
 
     // TODO: Contractions break the tagger (don't does not get a tag etc)
 
-    //let sentence = "every man and some woman likes cheese";
-    let sentence = "john likes every cheese and every man and some woman likes gouda";
+    //let sentence = "every man likes every cheese";
+    let sentence = "john likes every cheese and every man and some woman likes brie";
     // retrieve words and their corresponding pos tags
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);
 

--- a/src/monty/lambda_generation.rs
+++ b/src/monty/lambda_generation.rs
@@ -178,8 +178,9 @@ pub fn ccg_to_lambda_recursive(current_node: CCGNode, root: &CCGNode) -> Box<Lam
                 return ccg_to_lambda_recursive(right.clone(), root);
             }
 
-            // TODO: this is wrong in some cases part of the sentence is not reduced, and in others it results in incorrect derivations
-            if right.contains_quantification_node() && left.contains_quantification_node() && left.clone().node_type != CCGType::Sentence && right.clone().node_type != CCGType::Sentence {
+            // both sides are quantified expressions
+            // e.g. EVERY MAN, LIKES SOME CHEESE
+            if current_node.node_type == CCGType::Sentence && right.contains_quantification_node() && left.contains_quantification_node() && left.clone().node_type != CCGType::Sentence && right.clone().node_type != CCGType::Sentence {
                 return ccg_to_lambda_recursive(left.clone(), root);
             }
 

--- a/src/monty/lambda_generation.rs
+++ b/src/monty/lambda_generation.rs
@@ -144,10 +144,8 @@ pub fn ccg_to_lambda_recursive(current_node: CCGNode, root: &CCGNode) -> Box<Lam
     use LambdaEntity::*;
 
     // Handle quantifier nodes
-    if let Some(word) = current_node.clone().word {
-        if UNIVERSAL_QUANTIFIERS.contains(&word.text) || EXISTENTIAL_QUANTIFIERS.contains(&word.text) {
-            return ccg_to_quantifier(current_node.clone(), root);
-        }
+    if current_node.is_quantification_node() {
+        return ccg_to_quantifier(current_node.clone(), root);
     }
 
     match current_node.rule {
@@ -173,9 +171,9 @@ pub fn ccg_to_lambda_recursive(current_node: CCGNode, root: &CCGNode) -> Box<Lam
                 return ccg_to_lambda_recursive(right.clone(), root);
             }
 
-            if right.contains_quantification_node() && left.contains_quantification_node() {
+            /*if right.contains_quantification_node() && left.contains_quantification_node() {
                 return ccg_to_lambda_recursive(left.clone(), root);
-            }
+            }*/
 
 
 

--- a/src/monty/lambda_generation.rs
+++ b/src/monty/lambda_generation.rs
@@ -179,7 +179,7 @@ pub fn ccg_to_lambda_recursive(current_node: CCGNode, root: &CCGNode) -> Box<Lam
             }
 
             // TODO: this is wrong in some cases part of the sentence is not reduced, and in others it results in incorrect derivations
-            if right.contains_quantification_node() && left.contains_quantification_node() {
+            if right.contains_quantification_node() && left.contains_quantification_node() && left.clone().node_type != CCGType::Sentence && right.clone().node_type != CCGType::Sentence {
                 return ccg_to_lambda_recursive(left.clone(), root);
             }
 

--- a/src/monty/lambda_generation.rs
+++ b/src/monty/lambda_generation.rs
@@ -101,7 +101,7 @@ pub fn ccg_to_lambda(root: &mut CCGNode) -> Box<LambdaEntity> {
 
 pub fn ccg_to_quantifier(node: CCGNode, root: &CCGNode) -> Box<LambdaEntity> {
     let bound_var_node = node.get_sibling(root).expect("Expected quantification node to have a sibling");
-    let bound_var = ccg_to_lambda_recursive(bound_var_node.clone(), root);
+    let mut bound_var = ccg_to_lambda_recursive(bound_var_node.clone(), root);
     let quantified_phrase = node.get_parent(root).expect("Expected quantification node to have a parent");
 
     let expr;
@@ -110,10 +110,21 @@ pub fn ccg_to_quantifier(node: CCGNode, root: &CCGNode) -> Box<LambdaEntity> {
     } else if let Some(expr_node) = quantified_phrase.backtrack_until_lhs(root) {
         let lhs = expr_node.get_sibling(root).expect("Expected quantification node to have a sibling");
         let (left, right) = unpack_children(lhs.clone().children);
-        expr = λApp!(ccg_to_lambda_recursive(left.clone(), root), ccg_to_lambda_recursive(expr_node.clone(), root));
+        let mut applied_var = ccg_to_lambda_recursive(expr_node.clone(), root);
+        (bound_var, applied_var) = (applied_var, bound_var);
+        expr = λApp!(ccg_to_lambda_recursive(left.clone(), root), applied_var);
+        println!("expr: {}", expr)
 
     } else {
-        panic!("Expected expression on left or right");
+        // both expressions are quantifiers e.g. EVERY MAN, LIKES EVERY CHEESE
+        let left_quantifier = node.get_sibling(root).expect("Expected left quantifier sibling");
+        let right_quantifier = quantified_phrase.get_sibling(root).expect("Expected right quantifier sibling");
+
+        let left_expr = ccg_to_lambda_recursive(left_quantifier.clone(), root);
+        let right_expr = ccg_to_lambda_recursive(right_quantifier.clone(), root);
+
+        expr = λApp!(left_expr, right_expr);
+
     }
 
     if node.is_universal_quantification_node {

--- a/src/monty/lambda_generation.rs
+++ b/src/monty/lambda_generation.rs
@@ -104,46 +104,27 @@ pub fn ccg_to_quantifier(node: CCGNode, root: &CCGNode) -> Box<LambdaEntity> {
     let mut bound_var = ccg_to_lambda_recursive(bound_var_node.clone(), root);
     let quantified_phrase = node.get_parent(root).expect("Expected quantification node to have a parent");
 
-    let expr;
-
-    if let Some(expr_node) = quantified_phrase.backtrack_until_rhs(root) {
-        expr = ccg_to_lambda_recursive(expr_node.clone(), root);
+    let expr = if let Some(expr_node) = quantified_phrase.backtrack_until_rhs(root) {
+        // The quantifier is on the left hand side. e.g. "EVERY MAN, LIKES CHEESE"
+        ccg_to_lambda_recursive(expr_node.clone(), root)
     } else if let Some(expr_node) = quantified_phrase.backtrack_until_lhs(root) {
+        // The quantifier is on the right hand side. e.g. "JOHN, LIKES EVERY CHEESE"
         let lhs = expr_node.get_sibling(root).expect("Expected quantification node to have a sibling");
-        let (left, right) = unpack_children(lhs.clone().children);
+        let (left, _) = unpack_children(lhs.clone().children);
         let mut applied_var = ccg_to_lambda_recursive(expr_node.clone(), root);
         (bound_var, applied_var) = (applied_var, bound_var);
-        expr = λApp!(ccg_to_lambda_recursive(left.clone(), root), applied_var);
-        println!("expr: {}", expr)
-
+        λApp!(ccg_to_lambda_recursive(left.clone(), root), applied_var)
     } else {
-        // both expressions are quantifiers e.g. EVERY MAN, LIKES EVERY CHEESE
-        // TODO: apply the bound_var before the recursive call.
-
-        println!("left expr: {}", bound_var);
-
+        // The quantifiers are on both sides. e.g. "EVERY MAN, LIKES SOME CHEESE"
         let right_quantifier = quantified_phrase.get_sibling(root).expect("Expected right quantifier sibling");
+        ccg_to_lambda_recursive(right_quantifier.clone(), root)
+    };
 
-        let right_expr = ccg_to_lambda_recursive(right_quantifier.clone(), root);
-
-        println!("right expr: {}", right_expr);
-
-
-
-        expr = right_expr
-
+    match node.word.map(|w| w.text) {
+        Some(q) if UNIVERSAL_QUANTIFIERS.contains(&q) => λDepFun!(bound_var.clone(), λApp!(expr, bound_var)),
+        Some(q) if EXISTENTIAL_QUANTIFIERS.contains(&q) => λDepSum!(bound_var.clone(), λApp!(expr, bound_var)),
+        _ => panic!("Expected quantification node to be existential or universal"),
     }
-
-    if let Some(word) = node.word {
-        if UNIVERSAL_QUANTIFIERS.contains(&word.text) {
-            λDepFun!(bound_var.clone(), λApp!(expr, bound_var))
-        }
-        else if EXISTENTIAL_QUANTIFIERS.contains(&word.text) {
-            λDepSum!(bound_var.clone(), λApp!(expr, bound_var))
-        }
-        else {panic!("Expected quantification node to be existential or universal")}
-    }
-    else {panic!("Expected quantification node to be terminal")}
 }
 
 

--- a/src/monty/lambda_generation.rs
+++ b/src/monty/lambda_generation.rs
@@ -14,6 +14,7 @@ use crate::lambda::dependent_function::DependentFunction;
 use crate::lambda::variable::Variable;
 use crate::lambda::dependent_sum::DependentSum;
 use crate::{λAbs, λVar, λApp, λPred, λConj, λDepFun, λDepSum};
+use crate::brill::contextual_rulespec::left_bigram;
 use crate::lingo::quantifiers::{UNIVERSAL_QUANTIFIERS, EXISTENTIAL_QUANTIFIERS};
 
 
@@ -95,7 +96,6 @@ fn unpack_children(maybe_nodes: Option<Vec<Box<CCGNode>>>) -> (CCGNode, CCGNode)
 }
 
 pub fn ccg_to_lambda(root: &mut CCGNode) -> Box<LambdaEntity> {
-    root.initialize_flags();
     ccg_to_lambda_recursive(root.clone(), root)
 }
 
@@ -105,6 +105,7 @@ pub fn ccg_to_quantifier(node: CCGNode, root: &CCGNode) -> Box<LambdaEntity> {
     let quantified_phrase = node.get_parent(root).expect("Expected quantification node to have a parent");
 
     let expr;
+
     if let Some(expr_node) = quantified_phrase.backtrack_until_rhs(root) {
         expr = ccg_to_lambda_recursive(expr_node.clone(), root);
     } else if let Some(expr_node) = quantified_phrase.backtrack_until_lhs(root) {
@@ -117,33 +118,36 @@ pub fn ccg_to_quantifier(node: CCGNode, root: &CCGNode) -> Box<LambdaEntity> {
 
     } else {
         // both expressions are quantifiers e.g. EVERY MAN, LIKES EVERY CHEESE
-        let left_quantifier = node.get_sibling(root).expect("Expected left quantifier sibling");
         let right_quantifier = quantified_phrase.get_sibling(root).expect("Expected right quantifier sibling");
-
-        let left_expr = ccg_to_lambda_recursive(left_quantifier.clone(), root);
         let right_expr = ccg_to_lambda_recursive(right_quantifier.clone(), root);
 
-        expr = λApp!(left_expr, right_expr);
+        println!("left expr: {} \n right expr: {}", bound_var, right_expr);
+
+        expr = right_expr
 
     }
 
-    if node.is_universal_quantification_node {
-        λDepFun!(bound_var.clone(), λApp!(expr, bound_var))
+    if let Some(word) = node.word {
+        if UNIVERSAL_QUANTIFIERS.contains(&word.text) {
+            λDepFun!(bound_var.clone(), λApp!(expr, bound_var))
+        }
+        else if EXISTENTIAL_QUANTIFIERS.contains(&word.text) {
+            λDepSum!(bound_var.clone(), λApp!(expr, bound_var))
+        }
+        else {panic!("Expected quantification node to be existential or universal")}
     }
-    else if node.is_existential_quantification_node {
-        λDepSum!(bound_var.clone(), λApp!(expr, bound_var))
-    }
-    else {panic!("Expected quantification node to be existential or universal")}
+    else {panic!("Expected quantification node to be terminal")}
 }
-
 
 
 pub fn ccg_to_lambda_recursive(current_node: CCGNode, root: &CCGNode) -> Box<LambdaEntity> {
     use LambdaEntity::*;
 
     // Handle quantifier nodes
-    if current_node.is_universal_quantification_node || current_node.is_existential_quantification_node {
-        return ccg_to_quantifier(current_node.clone(), root);
+    if let Some(word) = current_node.clone().word {
+        if UNIVERSAL_QUANTIFIERS.contains(&word.text) || EXISTENTIAL_QUANTIFIERS.contains(&word.text) {
+            return ccg_to_quantifier(current_node.clone(), root);
+        }
     }
 
     match current_node.rule {
@@ -169,6 +173,12 @@ pub fn ccg_to_lambda_recursive(current_node: CCGNode, root: &CCGNode) -> Box<Lam
                 return ccg_to_lambda_recursive(right.clone(), root);
             }
 
+            if right.contains_quantification_node() && left.contains_quantification_node() {
+                return ccg_to_lambda_recursive(left.clone(), root);
+            }
+
+
+
 
             return λApp!(
                 ccg_to_lambda_recursive(right, root),
@@ -183,11 +193,11 @@ pub fn ccg_to_lambda_recursive(current_node: CCGNode, root: &CCGNode) -> Box<Lam
 
             // right hand side is quantified expression. left hand side is expr
             // e.g. JOHN LIKES, EVERY CHEESE
-            if left.contains_quantification_node() {
+            if left.contains_quantification_node() && !right.contains_quantification_node() {
                 return ccg_to_lambda_recursive(left.clone(), root);
             }
 
-            if right.contains_quantification_node() {
+            if right.contains_quantification_node() && !left.contains_quantification_node() {
                 return ccg_to_lambda_recursive(right.clone(), root);
             }
 

--- a/src/monty/lambda_generation.rs
+++ b/src/monty/lambda_generation.rs
@@ -118,10 +118,17 @@ pub fn ccg_to_quantifier(node: CCGNode, root: &CCGNode) -> Box<LambdaEntity> {
 
     } else {
         // both expressions are quantifiers e.g. EVERY MAN, LIKES EVERY CHEESE
+        // TODO: apply the bound_var before the recursive call.
+
+        println!("left expr: {}", bound_var);
+
         let right_quantifier = quantified_phrase.get_sibling(root).expect("Expected right quantifier sibling");
+
         let right_expr = ccg_to_lambda_recursive(right_quantifier.clone(), root);
 
-        println!("left expr: {} \n right expr: {}", bound_var, right_expr);
+        println!("right expr: {}", right_expr);
+
+
 
         expr = right_expr
 
@@ -171,12 +178,10 @@ pub fn ccg_to_lambda_recursive(current_node: CCGNode, root: &CCGNode) -> Box<Lam
                 return ccg_to_lambda_recursive(right.clone(), root);
             }
 
-            /*if right.contains_quantification_node() && left.contains_quantification_node() {
+            // TODO: this is wrong in some cases part of the sentence is not reduced, and in others it results in incorrect derivations
+            if right.contains_quantification_node() && left.contains_quantification_node() {
                 return ccg_to_lambda_recursive(left.clone(), root);
-            }*/
-
-
-
+            }
 
             return λApp!(
                 ccg_to_lambda_recursive(right, root),

--- a/src/monty/lambda_generation.rs
+++ b/src/monty/lambda_generation.rs
@@ -14,7 +14,6 @@ use crate::lambda::dependent_function::DependentFunction;
 use crate::lambda::variable::Variable;
 use crate::lambda::dependent_sum::DependentSum;
 use crate::{λAbs, λVar, λApp, λPred, λConj, λDepFun, λDepSum};
-use crate::brill::contextual_rulespec::left_bigram;
 use crate::lingo::quantifiers::{UNIVERSAL_QUANTIFIERS, EXISTENTIAL_QUANTIFIERS};
 
 


### PR DESCRIPTION
## Pull Request Description
Handle quantifiers over quantifiers, e.g. `every man likes every cheese`. Quantification nodes have been removed, as `ccg_to_quantifier` is now called on terminal quantifying nodes, e.g. `Every`, rather than entire expressions.

In order to fully reduce embedded quantifiers, e.g.`Π(man) ((Π(cheese) (((λx2. (λx1. likes(x1, x2))) cheese)) man))`, substitution for dependent functions and dependent sums was altered. Applications can be applied inside of inner `expr`s. e.g. `Π(man) ((Π(cheese) (((λx2. (λx1. likes(x1, x2))) cheese)) man))` -> `Π(man) (Π(cheese) (likes(man, cheese)))`.

### This pull request introduces the following updates:
- [X] Resolves one or more bugs (non-breaking modification that addresses an issue).
- [ ] Introduces one or more new features (non-breaking addition of new functionality).
- [ ] Adds documentation (such as Doxygen or other relevant documentation formats).
- [X] Refactors code (non-breaking change aimed at improving code structure or readability).
- [ ] Adds one or more tests to the repository.
- [ ] Includes additional modifications (please specify).

### Commitments to the repository:
- [X] I have conducted a thorough self-review of the code.
- [ ] I have implemented tests that validate the functionality of the fix or feature.
- [X] I have updated relevant documentation to reflect the changes made.
- [X] My changes do not introduce any new warnings or errors.
