### PR TITLE
89 fix agda record names and entity resolution

### DIFF
--- a/src/composer/agdaify.rs
+++ b/src/composer/agdaify.rs
@@ -30,7 +30,7 @@ fn format_agda_type_prec(agda_type: &AgdaType, prec: u8) -> String {
             // The argument is printed in an even tighter context.
             let arg_str = format_agda_type_prec(arg, my_prec + 1);
             let s = format!("{} {}", func_str, arg_str);
-            if my_prec < prec { format!("({})", s) } else { s }
+            if my_prec < prec { format!("({})", s) } else { format!("({})", s) }
         }
 
         AgdaType::RecordProj(rec, proj) => {

--- a/src/composer/agdaify.rs
+++ b/src/composer/agdaify.rs
@@ -30,7 +30,7 @@ fn format_agda_type_prec(agda_type: &AgdaType, prec: u8) -> String {
             // The argument is printed in an even tighter context.
             let arg_str = format_agda_type_prec(arg, my_prec + 1);
             let s = format!("{} {}", func_str, arg_str);
-            if my_prec < prec { format!("({})", s) } else { format!("({})", s) }
+            if my_prec < prec { format!("({})", s) } else { s }
         }
 
         AgdaType::RecordProj(rec, proj) => {

--- a/src/composer/lambda_to_types.rs
+++ b/src/composer/lambda_to_types.rs
@@ -344,7 +344,6 @@ pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> 
 
     /* We need to also update the postulate to include the isType function */
     f.insert_postulate(PostulateEntry(predicate_iden, generate_function_header(1)));
-
     f.insert_definition(AgdaStructure::RecordDef(rec));
 
     let projection = τApp!(τRecProj!( τSimp!(record_name.clone()) , τSimp!("e₁".to_string()) ), τSimp!("e₁".to_string()));

--- a/src/composer/lambda_to_types.rs
+++ b/src/composer/lambda_to_types.rs
@@ -158,11 +158,9 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
     }
 
     /* Append record fields to the name and constructor name of the record. */
-
     record_name.extend(var_idens.iter().map(|v| {
         format!("_{}", symbol_table.get(v).unwrap().clone())
     }));
-
     constructor_name.extend(var_idens.iter().map(|v| {
         format!("_{}", symbol_table.get(v).unwrap().clone())
     }));
@@ -194,10 +192,22 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
         /* This is now if we're saying `every` something is something! */
         let mut props_copy = props.clone();
-        println!("PROPS HERE: {:?}", props_copy);
+
+        println!("Creating record for {}. \n uquants {:?}. \n equants {:?}. \n props {:?}.\n fields: {:?}.", iden, uquants, equants.clone(), props, fields);
+
+
+        /* Append record fields to the name and constructor name of the record. */
+        record_name.extend(props_copy.iter().map(|v| {
+            format!("_{}", v.name)
+        }));
+        constructor_name.extend(props_copy.iter().map(|v| {
+            format!("_{}", v.name)
+        }));
+
         let mut returned_proofs: Vec<Box<AgdaType>> = vec![];
         while !props_copy.is_empty() {
             let current_prop = props_copy.pop().unwrap();
+
             let mut c_predicate = convert_case(format!("is_{}", current_prop).as_str(), CaseStyle::CamelCase);
             let (source_iden, typ) = uquants.get(0).unwrap();
 
@@ -239,7 +249,6 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
     /* Now, we need to insert the record for it */
 
-    println!("Creating record for {}. \n uquants {:?}. \n equants {:?}. \n props {:?}.\n fields: {:?}.", iden, uquants, equants.clone(), props, fields);
 
     /* Format record and constructor names correctly. */
 

--- a/src/composer/lambda_to_types.rs
+++ b/src/composer/lambda_to_types.rs
@@ -79,7 +79,7 @@ fn replace_innermost_simple(expr: AgdaType, new_value: AgdaType) -> AgdaType {
 }
 
 
-pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
+pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable>) -> (String, Option<AgdaType>) {
 
     /* Handle the unwrapping the onion of is */
     if p.iden == "is" && p.args.len() > 1 {
@@ -144,7 +144,7 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
             }
         }
     }
-    let mut symbol_table: HashMap<String, (String, AgdaType)> = HashMap::new();
+    let mut symbol_table: HashMap<String, (String, Option<AgdaType>)> = HashMap::new();
 
     /* Handle Entity Fields */
     let mut fields: Vec<RecordField> = vec![];
@@ -191,7 +191,7 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
          inner = var_idens.iter().fold(
             τSimp!(iden.clone()),
             |acc, name| {
-                let proj = symbol_table.get(name).unwrap().clone().1;
+                let proj = symbol_table.get(name).unwrap().clone().1.expect("Expected record to contain a projection");
                 let app_proj = replace_innermost_simple(proj, *τSimp!(name.clone()));
                 τApp!(acc,
                         Box::from(app_proj)
@@ -203,7 +203,8 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
         /* If it's an is, then this inside will be well... different! */
         if uquants.is_empty() {
             match *(p.args.get(0).unwrap().clone()) {
-                Var(v) => { return compose_variable(v, f, props) }
+                Var(v) => {
+                    return compose_variable(v, f, props) }
                 _ => { panic!("Invalid!") }
             }
         }
@@ -228,7 +229,7 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
 
             returned_proofs.push(τApp!(τSimp!(c_predicate.clone()),
-                        Box::from(symbol_table.get(&source_iden.name).unwrap().clone().1)
+                        Box::from(symbol_table.get(&source_iden.name).unwrap().clone().1.expect("Expected record to contain a projection"))
             ));
 
             f.insert_postulate(PostulateEntry(c_predicate, generate_function_header(1)));
@@ -293,22 +294,18 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
     let projection =
     if fields.len() == 2 {
-        let outer_projection = symbol_table.get("e₁").unwrap().clone().1;
+        let outer_projection = symbol_table.get("e₁").unwrap().clone().1.expect("Expected record to contain a projection");
         let application = *τApp!( τRecProj!( τSimp!(record_name.clone()) , τSimp!("e₁".to_string()) ), τSimp!("e₁".to_string()));
-        replace_innermost_simple(outer_projection, application)
+        Some(replace_innermost_simple(outer_projection, application))
     } else {
-        *τSimp!("Not Used".to_string())
+        None
     };
-
-    // let projection = get_projection(fields, &symbol_table, &*record_name);
-
-    println!("PROJECTION OF {} : {:?}", record_name, projection.clone());
 
     (record_name, projection)
 }
 
 
-pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
+pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> (String, Option<AgdaType>) {
 
     use AgdaType::*;
     let iden = v.name;
@@ -351,39 +348,11 @@ pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> 
     f.insert_definition(AgdaStructure::RecordDef(rec));
 
     let projection = τApp!(τRecProj!( τSimp!(record_name.clone()) , τSimp!("e₁".to_string()) ), τSimp!("e₁".to_string()));
-    (record_name, *projection)
-}
-
-fn get_projection(fields: Vec<RecordField>, symbol_table: &HashMap<String, (String, AgdaType)>, record_name: &str) -> AgdaType {
-    if fields.len() == 2 {
-        let mut outer_projection = symbol_table.get("e₁").unwrap().clone().1;
-
-        // Traverse the application chain to find the innermost rhs
-        while let AgdaType::Application(lhs, rhs) = outer_projection {
-            outer_projection = *rhs;
-        }
-
-        // At this point, `outer_projection` is the innermost rhs
-        // Now, create a new application with the desired modification
-        if let AgdaType::Application(lhs, _) = outer_projection {
-            return *τApp!(
-                lhs,
-                τApp!(
-                    τRecProj!(τSimp!(record_name.to_string()), τSimp!("e₁".to_string())),
-                    τSimp!("e₁".to_string())
-                )
-            );
-        } else {
-            panic!("Projection is of incorrect form")
-        }
-    }
-
-    // Base case: return a simple type indicating unused projection
-    *τSimp!("Not Used".to_string())
+    (record_name, Some(*projection))
 }
 
 
-pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> (String, AgdaType) {
+pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> (String, Option<AgdaType>) {
 
     /* Extract projections */
     let proj1 = c.lhs;
@@ -417,12 +386,12 @@ pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> (String, AgdaType) {
     };
 
     f.insert_definition(AgdaStructure::RecordDef(rec));
-    (record_name, *τSimp!("Temporary".to_string()))
+    (record_name, None)
 }
 
 
 
-pub fn compose(e: Box<LambdaEntity>, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
+pub fn compose(e: Box<LambdaEntity>, f: &mut AgdaFile, props: Vec<Variable>) -> (String, Option<AgdaType>) {
 
     match *e {
 

--- a/src/composer/lambda_to_types.rs
+++ b/src/composer/lambda_to_types.rs
@@ -4,7 +4,7 @@ use crate::ccg::rule::CCGRule;
 use crate::composer::postulate::{initialise_agda_file, AgdaFile, AgdaStructure, DefinitionInserter, PostulateEntry, PostulateInserter};
 use crate::composer::record::{RecordDefinition, RecordField};
 use crate::composer::structures::{AgdaType};
-use crate::composer::structures::AgdaType::Simple;
+use crate::composer::structures::AgdaType::{Application, Simple};
 use crate::lambda::predicate::Predicate;
 use crate::lambda::types::LambdaEntity;
 use crate::lambda::variable::Variable;
@@ -58,8 +58,28 @@ pub fn contains_uquant(l: Box<LambdaEntity>) -> bool {
     }
 }
 
+fn replace_innermost_simple(expr: AgdaType, new_value: AgdaType) -> AgdaType {
+    match expr {
 
-pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable>) -> String {
+        // If the current expression is an App, recursively replace in the nested expression
+        Application(lhs, rhs) => {
+            let new_rhs = replace_innermost_simple(*rhs.clone(), new_value.clone());
+            // let new_lhs = replace_innermost_simple(*lhs, new_value.clone());
+
+            // Continue with recursive replacement on the right side of the app chain
+            if let Application(_, _) = *rhs {
+                Application(lhs.clone(), Box::new(new_rhs))
+            } else {
+                Application(lhs.clone(), Box::new(new_rhs))
+            }
+        }
+        // If the current expression is a Simple, replace it with the new_value
+        _ => new_value,
+    }
+}
+
+
+pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
 
     /* Handle the unwrapping the onion of is */
     if p.iden == "is" && p.args.len() > 1 {
@@ -124,16 +144,16 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
             }
         }
     }
-    let mut symbol_table: HashMap<String, String> = HashMap::new();
+    let mut symbol_table: HashMap<String, (String, AgdaType)> = HashMap::new();
 
     /* Handle Entity Fields */
     let mut fields: Vec<RecordField> = vec![];
     for (field_iden, arg) in equants.clone() {
 
         /* This will likely rely on records from here! */
-        let rec_name = compose(arg.clone(), f, vec![]);
+        let (rec_name, rec_proj) = compose(arg.clone(), f, vec![]);
         fields.push(RecordField(field_iden.to_string(), Simple(rec_name.clone())));
-        symbol_table.insert(field_iden.name, rec_name);
+        symbol_table.insert(field_iden.name, (rec_name, rec_proj));
     }
 
     /* Build the proof type as: iden e₁ e₂ ... eₙ */
@@ -154,10 +174,10 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
     /* Append record fields to the name and constructor name of the record. */
     record_name.extend(var_idens.iter().map(|v| {
-        format!("_{}", symbol_table.get(v).unwrap().clone())
+        format!("_{}", symbol_table.get(v).unwrap().0.clone())
     }));
     constructor_name.extend(var_idens.iter().map(|v| {
-        format!("_{}", symbol_table.get(v).unwrap().clone())
+        format!("_{}", symbol_table.get(v).unwrap().0.clone())
     }));
 
 
@@ -171,14 +191,12 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
          inner = var_idens.iter().fold(
             τSimp!(iden.clone()),
             |acc, name| {
+                let proj = symbol_table.get(name).unwrap().clone().1;
+                let app_proj = replace_innermost_simple(proj, *τSimp!(name.clone()));
                 τApp!(acc,
-                    τApp!(
-                        τRecProj!( τSimp!(symbol_table.get(name).unwrap().clone()) , τSimp!("e₁".to_string()) ),
-                        τSimp!(name.clone())
-                    )
+                        Box::from(app_proj)
                 )
             }
-
         );
     }
     else {
@@ -208,11 +226,9 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
             let mut c_predicate = convert_case(format!("is_{}", current_prop).as_str(), CaseStyle::CamelCase);
             let (source_iden, typ) = uquants.get(0).unwrap();
 
+
             returned_proofs.push(τApp!(τSimp!(c_predicate.clone()),
-                τApp!(
-                        τRecProj!( τSimp!(symbol_table.get(&source_iden.name).unwrap().clone()) , τSimp!("e₁".to_string()) ),
-                        τSimp!(source_iden.clone().name)
-                    )
+                        Box::from(symbol_table.get(&source_iden.name).unwrap().clone().1)
             ));
 
             f.insert_postulate(PostulateEntry(c_predicate, generate_function_header(1)));
@@ -235,7 +251,7 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
     /* For every uquant */
     while uquants.len() > 0 {
         let (current, typ) = uquants.pop().unwrap();
-        let rec_name =  symbol_table.get(&current.name.clone()).unwrap();
+        let rec_name =  symbol_table.get(&current.name.clone()).unwrap().0.clone();
 
         inner = τDepFunc!(current.name, τSimp!(rec_name.clone()), inner.clone());
     }
@@ -261,15 +277,38 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
     let rec = RecordDefinition {
         record_name: record_name.clone(),
         constructor_name: constructor_name,
-        fields: fields,
+        fields: fields.clone(),
     };
 
     f.insert_definition(AgdaStructure::RecordDef(rec));
-    record_name
+
+    // Get the projection of e1
+
+    /* IF there is only one entity, the projection matters
+        e.g. YellowCheese will be used
+
+        but if there is multiple entities, the projection will not be used.
+        e.g. LikesSocratesCheese
+        */
+
+    let projection =
+    if fields.len() == 2 {
+        let outer_projection = symbol_table.get("e₁").unwrap().clone().1;
+        let application = *τApp!( τRecProj!( τSimp!(record_name.clone()) , τSimp!("e₁".to_string()) ), τSimp!("e₁".to_string()));
+        replace_innermost_simple(outer_projection, application)
+    } else {
+        *τSimp!("Not Used".to_string())
+    };
+
+    // let projection = get_projection(fields, &symbol_table, &*record_name);
+
+    println!("PROJECTION OF {} : {:?}", record_name, projection.clone());
+
+    (record_name, projection)
 }
 
 
-pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> String {
+pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
 
     use AgdaType::*;
     let iden = v.name;
@@ -310,12 +349,41 @@ pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> 
     f.insert_postulate(PostulateEntry(predicate_iden, generate_function_header(1)));
 
     f.insert_definition(AgdaStructure::RecordDef(rec));
-    return record_name;
+
+    let projection = τApp!(τRecProj!( τSimp!(record_name.clone()) , τSimp!("e₁".to_string()) ), τSimp!("e₁".to_string()));
+    (record_name, *projection)
+}
+
+fn get_projection(fields: Vec<RecordField>, symbol_table: &HashMap<String, (String, AgdaType)>, record_name: &str) -> AgdaType {
+    if fields.len() == 2 {
+        let mut outer_projection = symbol_table.get("e₁").unwrap().clone().1;
+
+        // Traverse the application chain to find the innermost rhs
+        while let AgdaType::Application(lhs, rhs) = outer_projection {
+            outer_projection = *rhs;
+        }
+
+        // At this point, `outer_projection` is the innermost rhs
+        // Now, create a new application with the desired modification
+        if let AgdaType::Application(lhs, _) = outer_projection {
+            return *τApp!(
+                lhs,
+                τApp!(
+                    τRecProj!(τSimp!(record_name.to_string()), τSimp!("e₁".to_string())),
+                    τSimp!("e₁".to_string())
+                )
+            );
+        } else {
+            panic!("Projection is of incorrect form")
+        }
+    }
+
+    // Base case: return a simple type indicating unused projection
+    *τSimp!("Not Used".to_string())
 }
 
 
-
-pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> String {
+pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> (String, AgdaType) {
 
     /* Extract projections */
     let proj1 = c.lhs;
@@ -327,15 +395,15 @@ pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> String {
     use AgdaType::*;
 
     /* These sometimes have record identifiers in them ᵣ, remove! */
-    let iden: String = format!("{}×{}", proj1_iden.clone(), proj2_iden.clone())
+    let iden: String = format!("{}×{}", proj1_iden.clone().0, proj2_iden.clone().0)
         .chars()
         .filter(|&c| c != 'ᵣ')
         .collect();
 
     /* Generate Fields */
     let mut fields: Vec<RecordField> = vec![
-        RecordField("e₁".to_string(), *τSimp!(proj1_iden.clone())),
-        RecordField("e₂".to_string(), *τSimp!(proj2_iden.clone()))
+        RecordField("e₁".to_string(), *τSimp!(proj1_iden.clone().0)),
+        RecordField("e₂".to_string(), *τSimp!(proj2_iden.clone().0))
     ];
 
     /* Now, we need to insert the record for it */
@@ -349,12 +417,12 @@ pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> String {
     };
 
     f.insert_definition(AgdaStructure::RecordDef(rec));
-    record_name
+    (record_name, *τSimp!("Temporary".to_string()))
 }
 
 
 
-pub fn compose(e: Box<LambdaEntity>, f: &mut AgdaFile, props: Vec<Variable>) -> String {
+pub fn compose(e: Box<LambdaEntity>, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
 
     match *e {
 

--- a/src/composer/lambda_to_types.rs
+++ b/src/composer/lambda_to_types.rs
@@ -86,6 +86,11 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
         println!("Current Predicate: {}\nCurrent Props {:?}\n", p, props);
     }
 
+    let mut iden = format!("{}", p.iden);
+
+    let mut record_name = format!("{}ᵣ", convert_case(&*iden, CaseStyle::PascalCase));
+    let mut constructor_name = format!("{}꜀", convert_case(&*iden, CaseStyle::PascalCase));
+
 
     /* Initialise for dependent stuff */
     let mut uquants: Vec<(Variable, Box<LambdaEntity>)> = vec![];
@@ -119,21 +124,16 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
             }
         }
     }
-
-    /* At this point, the arguments to P should contain only references to objects in uquants and equants */
-    println!("Current Predicate: {}\nQuants: {:?}\nEQuants: {:?}\n\n", p, uquants, equants);
-
     let mut symbol_table: HashMap<String, String> = HashMap::new();
 
     /* We need to propose that the predicate itself is some propositional function over entity */
     /* i.e. e to e to Set                                                                      */
     let arg_c = p.args.len();
-    let mut iden = format!("{}", p.iden);
     f.insert_postulate(PostulateEntry(iden.clone(), generate_function_header(arg_c)));
 
     /* Handle Entity Fields */
     let mut fields: Vec<RecordField> = vec![];
-    for (field_iden, arg) in equants {
+    for (field_iden, arg) in equants.clone() {
 
         /* This will likely rely on records from here! */
         let rec_name = compose(arg.clone(), f, vec![]);
@@ -157,6 +157,17 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
         symbol_table.insert(current.name, rec_name);
     }
 
+    /* Append record fields to the name and constructor name of the record. */
+
+    record_name.extend(var_idens.iter().map(|v| {
+        format!("_{}", symbol_table.get(v).unwrap().clone())
+    }));
+
+    constructor_name.extend(var_idens.iter().map(|v| {
+        format!("_{}", symbol_table.get(v).unwrap().clone())
+    }));
+
+
     let mut inner = τSimp!("Temporary".parse().unwrap());
     if p.iden != "is" {
          inner = var_idens.iter().fold(
@@ -171,7 +182,8 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
             }
 
         );
-    } else {
+    }
+    else {
         /* If it's an is, then this inside will be well... different! */
         if uquants.is_empty() {
             match *(p.args.get(0).unwrap().clone()) {
@@ -182,6 +194,7 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
         /* This is now if we're saying `every` something is something! */
         let mut props_copy = props.clone();
+        println!("PROPS HERE: {:?}", props_copy);
         let mut returned_proofs: Vec<Box<AgdaType>> = vec![];
         while !props_copy.is_empty() {
             let current_prop = props_copy.pop().unwrap();
@@ -225,8 +238,19 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
 
     /* Now, we need to insert the record for it */
-    let record_name = format!("{}ᵣ", convert_case(&*iden, CaseStyle::PascalCase));
-    let constructor_name = format!("{}꜀", convert_case(&*iden, CaseStyle::PascalCase));
+
+    println!("Creating record for {}. \n uquants {:?}. \n equants {:?}. \n props {:?}.\n fields: {:?}.", iden, uquants, equants.clone(), props, fields);
+
+    /* Format record and constructor names correctly. */
+
+    record_name = format!(
+        "{}ᵣ",
+        convert_case(&*record_name.replace('ᵣ', ""), CaseStyle::PascalCase)
+    );
+    constructor_name = format!(
+        "{}꜀",
+        convert_case(&*constructor_name.replace('꜀', "").replace('ᵣ', ""), CaseStyle::PascalCase)
+    );
 
     let rec = RecordDefinition {
         record_name: record_name.clone(),

--- a/src/composer/lambda_to_types.rs
+++ b/src/composer/lambda_to_types.rs
@@ -347,7 +347,6 @@ pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> 
 
     /* We need to also update the postulate to include the isType function */
     f.insert_postulate(PostulateEntry(predicate_iden, generate_function_header(1)));
-
     f.insert_definition(AgdaStructure::RecordDef(rec));
 
     let projection = τApp!(τRecProj!( τSimp!(record_name.clone()) , τSimp!("e₁".to_string()) ), τSimp!("e₁".to_string()));

--- a/src/composer/lambda_to_types.rs
+++ b/src/composer/lambda_to_types.rs
@@ -79,7 +79,7 @@ fn replace_innermost_simple(expr: AgdaType, new_value: AgdaType) -> AgdaType {
 }
 
 
-pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
+pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable>) -> (String, Option<AgdaType>) {
 
     /* Handle the unwrapping the onion of is */
     if p.iden == "is" && p.args.len() > 1 {
@@ -144,7 +144,7 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
             }
         }
     }
-    let mut symbol_table: HashMap<String, (String, AgdaType)> = HashMap::new();
+    let mut symbol_table: HashMap<String, (String, Option<AgdaType>)> = HashMap::new();
 
     /* Handle Entity Fields */
     let mut fields: Vec<RecordField> = vec![];
@@ -191,7 +191,7 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
          inner = var_idens.iter().fold(
             τSimp!(iden.clone()),
             |acc, name| {
-                let proj = symbol_table.get(name).unwrap().clone().1;
+                let proj = symbol_table.get(name).unwrap().clone().1.expect("Expected record to contain a projection");
                 let app_proj = replace_innermost_simple(proj, *τSimp!(name.clone()));
                 τApp!(acc,
                         Box::from(app_proj)
@@ -203,7 +203,8 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
         /* If it's an is, then this inside will be well... different! */
         if uquants.is_empty() {
             match *(p.args.get(0).unwrap().clone()) {
-                Var(v) => { return compose_variable(v, f, props) }
+                Var(v) => {
+                    return compose_variable(v, f, props) }
                 _ => { panic!("Invalid!") }
             }
         }
@@ -228,7 +229,7 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
 
             returned_proofs.push(τApp!(τSimp!(c_predicate.clone()),
-                        Box::from(symbol_table.get(&source_iden.name).unwrap().clone().1)
+                        Box::from(symbol_table.get(&source_iden.name).unwrap().clone().1.expect("Expected record to contain a projection"))
             ));
 
             f.insert_postulate(PostulateEntry(c_predicate, generate_function_header(1)));
@@ -293,22 +294,18 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
     let projection =
     if fields.len() == 2 {
-        let outer_projection = symbol_table.get("e₁").unwrap().clone().1;
+        let outer_projection = symbol_table.get("e₁").unwrap().clone().1.expect("Expected record to contain a projection");
         let application = *τApp!( τRecProj!( τSimp!(record_name.clone()) , τSimp!("e₁".to_string()) ), τSimp!("e₁".to_string()));
-        replace_innermost_simple(outer_projection, application)
+        Some(replace_innermost_simple(outer_projection, application))
     } else {
-        *τSimp!("Not Used".to_string())
+        None
     };
-
-    // let projection = get_projection(fields, &symbol_table, &*record_name);
-
-    println!("PROJECTION OF {} : {:?}", record_name, projection.clone());
 
     (record_name, projection)
 }
 
 
-pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
+pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> (String, Option<AgdaType>) {
 
     use AgdaType::*;
     let iden = v.name;
@@ -351,7 +348,7 @@ pub fn compose_variable(v: Variable, f: &mut AgdaFile, props: Vec<Variable>) -> 
     f.insert_definition(AgdaStructure::RecordDef(rec));
 
     let projection = τApp!(τRecProj!( τSimp!(record_name.clone()) , τSimp!("e₁".to_string()) ), τSimp!("e₁".to_string()));
-    (record_name, *projection)
+    (record_name, Some(*projection))
 }
 
 fn get_projection(fields: Vec<RecordField>, symbol_table: &HashMap<String, (String, AgdaType)>, record_name: &str) -> AgdaType {
@@ -383,7 +380,7 @@ fn get_projection(fields: Vec<RecordField>, symbol_table: &HashMap<String, (Stri
 }
 
 
-pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> (String, AgdaType) {
+pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> (String, Option<AgdaType>) {
 
     /* Extract projections */
     let proj1 = c.lhs;
@@ -417,12 +414,12 @@ pub fn compose_product(c: Conjunction, f: &mut AgdaFile) -> (String, AgdaType) {
     };
 
     f.insert_definition(AgdaStructure::RecordDef(rec));
-    (record_name, *τSimp!("Temporary".to_string()))
+    (record_name, None)
 }
 
 
 
-pub fn compose(e: Box<LambdaEntity>, f: &mut AgdaFile, props: Vec<Variable>) -> (String, AgdaType) {
+pub fn compose(e: Box<LambdaEntity>, f: &mut AgdaFile, props: Vec<Variable>) -> (String, Option<AgdaType>) {
 
     match *e {
 

--- a/src/composer/lambda_to_types.rs
+++ b/src/composer/lambda_to_types.rs
@@ -126,11 +126,6 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
     }
     let mut symbol_table: HashMap<String, String> = HashMap::new();
 
-    /* We need to propose that the predicate itself is some propositional function over entity */
-    /* i.e. e to e to Set                                                                      */
-    let arg_c = p.args.len();
-    f.insert_postulate(PostulateEntry(iden.clone(), generate_function_header(arg_c)));
-
     /* Handle Entity Fields */
     let mut fields: Vec<RecordField> = vec![];
     for (field_iden, arg) in equants.clone() {
@@ -168,6 +163,11 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
     let mut inner = τSimp!("Temporary".parse().unwrap());
     if p.iden != "is" {
+        /* We need to propose that the predicate itself is some propositional function over entity */
+        /* i.e. e to e to Set                                                                      */
+        let arg_c = p.args.len();
+        f.insert_postulate(PostulateEntry(iden.clone(), generate_function_header(arg_c)));
+
          inner = var_idens.iter().fold(
             τSimp!(iden.clone()),
             |acc, name| {
@@ -192,9 +192,6 @@ pub fn compose_predicate(mut p: Predicate, f: &mut AgdaFile, props: Vec<Variable
 
         /* This is now if we're saying `every` something is something! */
         let mut props_copy = props.clone();
-
-        println!("Creating record for {}. \n uquants {:?}. \n equants {:?}. \n props {:?}.\n fields: {:?}.", iden, uquants, equants.clone(), props, fields);
-
 
         /* Append record fields to the name and constructor name of the record. */
         record_name.extend(props_copy.iter().map(|v| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let contextual_ruleset = parse_contextual_ruleset("data/rulefile_contextual.txt").unwrap();
     let mut wc_mapping = initialize_tagger("data/lexicon.txt").unwrap();
 
-    let sentence = "every socrates is big yellow cheese";
+    let sentence = "big yellow socrates likes cheese";
 
     let possible_tags = get_sentence_tags(sentence, &mut wc_mapping);
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let contextual_ruleset = parse_contextual_ruleset("data/rulefile_contextual.txt").unwrap();
     let mut wc_mapping = initialize_tagger("data/lexicon.txt").unwrap();
 
-    let sentence = "socrates likes big yellow cheese";
+    let sentence = "every socrates is big yellow cheese";
 
     let possible_tags = get_sentence_tags(sentence, &mut wc_mapping);
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ fn main() {
     let contextual_ruleset = parse_contextual_ruleset("data/rulefile_contextual.txt").unwrap();
     let mut wc_mapping = initialize_tagger("data/lexicon.txt").unwrap();
 
-    let sentence = "every john likes cheese and wine";
+    let sentence = "socrates likes big yellow cheese";
 
     let possible_tags = get_sentence_tags(sentence, &mut wc_mapping);
     let vec_of_word_tag_tuples = tag_sentence(sentence, &lexical_ruleset, &contextual_ruleset, &mut wc_mapping);


### PR DESCRIPTION
## Pull Request Description

- Fix record names: Predicate record names now include all arguments. This still fails for sentences with structure `pred(...) IS var` which will be addressed in a future issue.

- Fix entity resolution: each `compose` function now returns an extra `AgdaType` argument which explains how to access the innermost entity which is being described. 

### This pull request introduces the following updates:
- [X] Resolves one or more bugs (non-breaking modification that addresses an issue).
- [ ] Introduces one or more new features (non-breaking addition of new functionality).
- [X] Adds documentation (such as Doxygen or other relevant documentation formats).
- [ ] Refactors code (non-breaking change aimed at improving code structure or readability).
- [ ] Adds one or more tests to the repository.
- [ ] Includes additional modifications (please specify).

### Commitments to the repository:
- [X] I have conducted a thorough self-review of the code.
- [ ] I have implemented tests that validate the functionality of the fix or feature.
- [X] I have updated relevant documentation to reflect the changes made.
- [ ] My changes do not introduce any new warnings or errors.
